### PR TITLE
Changes to eWeapon_OnPickup

### DIFF
--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -206,7 +206,7 @@ bool AttemptGrabItem(int iClient)
 	eWeapon wep;
 	GetWeaponFromModel(wep, strModel);
 	
-	bool allow_pickup;
+	bool allow_pickup = true;
 	if (wep.on_pickup != INVALID_FUNCTION)
 	{
 		Call_StartFunction(null, wep.on_pickup);

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -206,16 +206,16 @@ bool AttemptGrabItem(int iClient)
 	eWeapon wep;
 	GetWeaponFromModel(wep, strModel);
 	
-	bool prevent_pickup;
+	bool allow_pickup;
 	if (wep.on_pickup != INVALID_FUNCTION)
 	{
 		Call_StartFunction(null, wep.on_pickup);
 		Call_PushCell(iClient);
-		Call_Finish(prevent_pickup);
+		Call_Finish(allow_pickup);
 	}
 	
 	// Do nothing if OnPickup callback returned false.
-	if (prevent_pickup)
+	if (!allow_pickup)
 		return false;
 	
 	if (wep.Rarity == eWeaponsRarity_Pickup)

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -214,12 +214,11 @@ bool AttemptGrabItem(int iClient)
 		Call_Finish(allow_pickup);
 	}
 	
-	// Do nothing if OnPickup callback returned false.
-	if (!allow_pickup)
-		return false;
-	
 	if (wep.Rarity == eWeaponsRarity_Pickup)
 	{
+		if (!allow_pickup)
+			return false;
+		
 		AcceptEntityInput(iTarget, ENT_ONKILL, iClient, iClient);
 		AcceptEntityInput(iTarget, "Kill");
 		
@@ -247,7 +246,7 @@ bool AttemptGrabItem(int iClient)
 		}
 		
 		int iSlot = TF2Econ_GetItemSlot(iIndex, TF2_GetPlayerClass(iClient));
-		if (iSlot >= 0)
+		if (iSlot >= 0 && allow_pickup)
 		{
 			if (nRarity == eWeaponsRarity_Rare)
 			{

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -118,7 +118,10 @@ public Action EventStart(Event event, const char[] name, bool dontBroadcast)
 				// else make it either common or uncommon weapon
 				else
 				{
-					if (GetRandomInt(0, GetRarityWeaponCount(eWeaponsRarity_Common)+GetRarityWeaponCount(eWeaponsRarity_Uncommon)) < GetRarityWeaponCount(eWeaponsRarity_Common))
+					int common_count = GetRarityWeaponCount(eWeaponsRarity_Common);
+					int uncommon_count = GetRarityWeaponCount(eWeaponsRarity_Uncommon);
+					
+					if (GetRandomInt(0, common_count + uncommon_count) < common_count)
 						SetRandomWeapon(iEntity, eWeaponsRarity_Common);
 					else
 						SetRandomWeapon(iEntity, eWeaponsRarity_Uncommon);
@@ -179,9 +182,7 @@ public Action EventVoiceMenu(int iClient, const char[] command, int argc)
 	{
 		// if an item was succesfully grabbed
 		if (AttemptGrabItem(iClient))
-		{
 			return Plugin_Handled;
-		}
 
 		return Plugin_Continue;
 	}
@@ -197,9 +198,7 @@ bool AttemptGrabItem(int iClient)
 	int iTarget = GetClientPointVisible(iClient);
 
 	if (iTarget <= 0 || !IsClassname(iTarget, "prop_dynamic") || GetWeaponType(iTarget) == eWeaponsType_Invalid)
-	{
 		return false;
-	}
 	
 	char strModel[256];
 	GetEntityModel(iTarget, strModel, sizeof(strModel));
@@ -498,9 +497,7 @@ public void PickupWeapon(int iClient, eWeapon wep, int iTarget)
 public Action ResetPickup(Handle timer, any iClient)
 {
 	if (IsValidClient(iClient))
-	{
 		g_bCanPickup[iClient] = true;
-	}
 }
 
 stock eWeaponsType GetWeaponType(int iEntity)
@@ -523,9 +520,7 @@ stock eWeaponsType GetWeaponType(int iEntity)
 stock void SwitchToSlot(int iClient, int iSlot)
 {
 	if (GetPlayerWeaponSlot(iClient, iSlot) > 0)
-	{
 		EquipPlayerWeapon(iClient, weapon);
-	}
 }
 
 stock void SetRandomPickup(int iEntity)

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -206,21 +206,22 @@ bool AttemptGrabItem(int iClient)
 	eWeapon wep;
 	GetWeaponFromModel(wep, strModel);
 	
-	bool destroy_pickup;
+	bool prevent_pickup;
 	if (wep.on_pickup != INVALID_FUNCTION)
 	{
 		Call_StartFunction(null, wep.on_pickup);
 		Call_PushCell(iClient);
-		Call_Finish(destroy_pickup);
+		Call_Finish(prevent_pickup);
 	}
+	
+	// Do nothing if OnPickup callback returned false.
+	if (prevent_pickup)
+		return false;
 	
 	if (wep.Rarity == eWeaponsRarity_Pickup)
 	{
-		if (destroy_pickup)
-		{
-			AcceptEntityInput(iTarget, ENT_ONKILL, iClient, iClient);
-			AcceptEntityInput(iTarget, "Kill");
-		}
+		AcceptEntityInput(iTarget, ENT_ONKILL, iClient, iClient);
+		AcceptEntityInput(iTarget, "Kill");
 		
 		return true;
 	}

--- a/addons/sourcemod/scripting/szf/weapons.sp
+++ b/addons/sourcemod/scripting/szf/weapons.sp
@@ -1,4 +1,4 @@
-typedef eWeapon_OnPickup = function bool (int client); // Return true to prevent client from picking up the item.
+typedef eWeapon_OnPickup = function bool (int client); // Return false to prevent client from picking up the item.
 
 static ArrayList g_Weapons;
 static ArrayList g_WepIndexesByRarity[eWeaponsRarity]; // Array indexes of g_Weapons array

--- a/addons/sourcemod/scripting/szf/weapons.sp
+++ b/addons/sourcemod/scripting/szf/weapons.sp
@@ -1,4 +1,4 @@
-typedef eWeapon_OnPickup = function bool (int client); // Return true if the pickup should be destroyed
+typedef eWeapon_OnPickup = function bool (int client); // Return true to prevent client from picking up the item.
 
 static ArrayList g_Weapons;
 static ArrayList g_WepIndexesByRarity[eWeaponsRarity]; // Array indexes of g_Weapons array

--- a/addons/sourcemod/scripting/szf/weapons.sp
+++ b/addons/sourcemod/scripting/szf/weapons.sp
@@ -134,10 +134,15 @@ void Weapons_ReplaceEntityModel(int ent, int index)
 // -----------------------------------------------------------
 public bool Weapons_OnPickup_Health(int client)
 {
-	SpawnPickup(client, "item_healthkit_full");
-	EmitSoundToClient(client, "ui/item_heavy_gun_pickup.wav");
+	if (GetClientHealth(client) < SDK_GetMaxHealth(client))
+	{
+		SpawnPickup(client, "item_healthkit_full");
+		EmitSoundToClient(client, "ui/item_heavy_gun_pickup.wav");
+		
+		return true;
+	}
 	
-	return true;
+	return false;
 }
 
 public bool Weapons_OnPickup_Ammo(int client)

--- a/addons/sourcemod/scripting/szf/weapons.sp
+++ b/addons/sourcemod/scripting/szf/weapons.sp
@@ -31,9 +31,7 @@ void Weapons_Init()
 			g_Weapons.GetArray(j, wep);
 			
 			if (wep.Rarity == view_as<eWeaponsRarity>(i))
-			{
 				g_WepIndexesByRarity[i].Push(j);
-			}
 		}
 	}
 }
@@ -91,7 +89,8 @@ ArrayList GetAllWeaponsWithRarity(eWeaponsRarity rarity)
 {
 	ArrayList array = new ArrayList(sizeof(eWeapon));
 	
-	for (int i = 0; i < GetRarityWeaponCount(rarity); i++)
+	int iLength = GetRarityWeaponCount(rarity);
+	for (int i = 0; i < iLength; i++)
 	{
 		eWeapon wep;
 		g_Weapons.GetArray(g_WepIndexesByRarity[rarity].Get(i), wep);


### PR DESCRIPTION
Returning false in a `eWeapon_OnPickup` function will now actually prevent player from picking up a weapon/pickup (Previously it was weird and would only work on pickups).

Also made medkit unpickable if player has full health.