### PR TITLE
Fixes for several sounds

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1681,8 +1681,6 @@ public Action event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 					SetEntityRenderColor(client, 255, 0, 0, 255);
 					CPrintToChat(client, "{green}YOU ARE A CHARGER:\n{orange}- Call 'MEDIC!' to CHARGE! {yellow}(16 second cooldown)");
 				}
-
-				g_ShouldBacteriaPlay[client] = false;
 			}
 
 
@@ -1709,8 +1707,6 @@ public Action event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 					SetEntityRenderColor(client, 150, 0, 255, 255);
 					CPrintToChat(client, "{green}YOU ARE A KINGPIN:\n{orange}- Call 'MEDIC!' to RALLY ALLIED ZOMBIES! {yellow}(21 second cooldown){orange}\n- Zombies standing near you are more powerful.");
 				}
-
-				g_ShouldBacteriaPlay[client] = false;
 			}
 
 			if (g_iSpecialInfected[client] == INFECTED_STALKER

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -5383,7 +5383,7 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1)
+				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1)  // the typo is intended because that's how the soundfiles are named
 				{
 					EmitSoundToAll(g_strZombieVO_Common_Death[GetRandomInt(0, sizeof(g_strZombieVO_Common_Death) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1145,8 +1145,10 @@ public Action hook_VoiceMenu(int client, const char[] command, int argc)
 				{
 					zf_rageTimer[client] = 31;
 					DoGenericRage(client);
+					char strPath[PLATFORM_MAX_PATH];
+					Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/rage_at_victim2%d.mp3", !GetRandomInt(0, 2) ? GetRandomInt(1, 2) : GetRandomInt(5, 6));
+					EmitSoundToAll(strPath, client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
-
 				if (g_iSpecialInfected[client] == INFECTED_BOOMER && g_bRoundActive)
 				{
 					DoBoomerExplosion(client, 600.0);
@@ -5384,45 +5386,37 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 	{
 		return Plugin_Continue;
 	}
-
+	
 	if (StrContains(sound, "vo/", false) != -1 && IsZombie(iClient))
 	{
+		if (StrContains(sound, "zombie_vo/", false) != -1) return Plugin_Continue; // so rage sounds (for normal & most special infected alike) don't get blocked
+		
 		// normal infected & kingpin(pitch only)
 		if (g_iSpecialInfected[iClient] == INFECTED_NONE || g_iSpecialInfected[iClient] == INFECTED_KINGPIN)
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				if (TF2_IsPlayerInCondition(iClient, TFCond_OnFire))
-				{
-					Format(sound, sizeof(sound), "left4fortress/zombie_vo/ignite0%d.mp3", GetRandomInt(7, 9));
-				}
-
-				else if (GetClientHealth(iClient) < 50 || StrContains(sound, "critical", false) != -1)
+				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1)
 				{
 					Format(sound, sizeof(sound), "left4fortress/zombie_vo/death_2%d.mp3", GetRandomInt(2, 9));
 				}
 
 				else
 				{
-					int iRandom = GetRandomInt(18, 22);
+					int iRandom = GetRandomInt(12, 24);
 					if (iRandom == 15 || iRandom == 16 || iRandom == 17 || iRandom == 23) iRandom = GetRandomInt(12, 14);
 					Format(sound, sizeof(sound), "left4fortress/zombie_vo/been_shot_%d.mp3", iRandom);
 				}
 			}
 
-			if (StrContains(sound, "_laugh", false) != -1 || StrContains(sound, "_no", false) != -1 || StrContains(sound, "_yes", false) != -1)
+			else if (StrContains(sound, "_laugh", false) != -1 || StrContains(sound, "_no", false) != -1 || StrContains(sound, "_yes", false) != -1)
 			{
 				Format(sound, sizeof(sound), "left4fortress/zombie_vo/mumbling0%d.mp3", GetRandomInt(1, 8));
 			}
 
-			if (StrContains(sound, "_go", false) != -1 || StrContains(sound, "_jarate", false) != -1)
+			else if (StrContains(sound, "_go", false) != -1 || StrContains(sound, "_jarate", false) != -1)
 			{
 				Format(sound, sizeof(sound), "left4fortress/zombie_vo/shoved_%d.mp3", GetRandomInt(1, 4));
-			}
-
-			if (StrContains(sound, "_medic", false) != -1)
-			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/rage_at_victim2%d.mp3", !GetRandomInt(0, 2) ? GetRandomInt(1, 2) : GetRandomInt(5, 6));
 			}
 
 			else
@@ -5714,7 +5708,7 @@ public void DoGenericRage(int iClient)
 	int curH = GetClientHealth(iClient);
 	SetEntityHealth(iClient, RoundToCeil(curH * 1.5));
 
-	ClientCommand(iClient, "voicemenu 2 1");
+	//ClientCommand(iClient, "voicemenu 2 1");
 
 	float fClientPos[3];
 	GetClientEyePosition(iClient, fClientPos);

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -890,9 +890,7 @@ public Action OnTakeDamage(int iVictim, int &iAttacker, int &iInflicter, float &
 
 			if (g_iSpecialInfected[iAttacker] == INFECTED_TANK)
 			{
-				char strPath[PLATFORM_MAX_PATH];
-				Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/tank_attack_0%d.mp3", GetRandomInt(1, 4));
-				EmitSoundToAll(strPath, iAttacker, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+				EmitSoundToAll(g_strZombieVO_Tank_Attack[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Attack) - 1)], iAttacker, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
@@ -1145,17 +1143,14 @@ public Action hook_VoiceMenu(int client, const char[] command, int argc)
 				{
 					zf_rageTimer[client] = 31;
 					DoGenericRage(client);
-					char strPath[PLATFORM_MAX_PATH];
-					Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/rage_at_victim2%d.mp3", !GetRandomInt(0, 2) ? GetRandomInt(1, 2) : GetRandomInt(5, 6));
-					EmitSoundToAll(strPath, client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+					
+					EmitSoundToAll(g_strZombieVO_Common_Rage[GetRandomInt(0, sizeof(g_strZombieVO_Common_Rage) - 1)], client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 				if (g_iSpecialInfected[client] == INFECTED_BOOMER && g_bRoundActive)
 				{
 					DoBoomerExplosion(client, 600.0);
 
-					char strPath[PLATFORM_MAX_PATH];
-					Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/male_boomer_disruptvomit_0%d.mp3", GetRandomInt(5, 7));
-					EmitSoundToAll(strPath, client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+					EmitSoundToAll(g_strZombieVO_Boomer_Explode[GetRandomInt(0, sizeof(g_strZombieVO_Boomer_Explode) - 1)], client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 
 				if (g_iSpecialInfected[client] == INFECTED_CHARGER)
@@ -1169,9 +1164,7 @@ public Action hook_VoiceMenu(int client, const char[] command, int argc)
 					vecVel[1] = 450.0 * Sine(DegToRad(vecAngles[1]));
 					TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, vecVel);
 					
-					char strPath[PLATFORM_MAX_PATH];
-					Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/charger_charge_0%d.mp3", GetRandomInt(1, 2));
-					EmitSoundToAll(strPath, client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+					EmitSoundToAll(g_strZombieVO_Charger_Charge[GetRandomInt(0, sizeof(g_strZombieVO_Charger_Charge) - 1)], client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 
 				if (g_iSpecialInfected[client] == INFECTED_KINGPIN)
@@ -1189,9 +1182,7 @@ public Action hook_VoiceMenu(int client, const char[] command, int argc)
 					zf_rageTimer[client] = 3;
 					DoHunterJump(client);
 
-					char strPath[PLATFORM_MAX_PATH];
-					Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/hunter_attackmix_0%d.mp3", GetRandomInt(1, 3));
-					EmitSoundToAll(strPath, client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+					EmitSoundToAll(g_strZombieVO_Hunter_Leap[GetRandomInt(0, sizeof(g_strZombieVO_Hunter_Leap) - 1)], client, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 			}
 
@@ -1606,9 +1597,7 @@ public Action event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 						}
 						else
 						{
-							char strSound[PLATFORM_MAX_PATH];
-							Format(strSound, sizeof(strSound), "left4fortress/zombie_vo/tank_voice_0%d.mp3", GetRandomInt(1, 4));
-							EmitSoundToAll(strSound);
+							EmitSoundToAll(g_strZombieVO_Tank_Default[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Default) - 1)]);
 						}
 					}
 
@@ -1886,9 +1875,7 @@ public Action event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		int iWinner = 0;
 		float fHighest = 0.0;
 				
-		char strPath[PLATFORM_MAX_PATH];
-		Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/tank_death_0%d.mp3", GetRandomInt(1, 4));
-		EmitSoundToAll(strPath);
+		EmitSoundToAll(g_strZombieVO_Tank_Death[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Death) - 1)], victim, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				
 		for (int i = 1; i <= MaxClients; i++)
 		{
@@ -5396,32 +5383,30 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1) // the typo is intended because that's how the soundfiles are named
+				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1)
 				{
-					Format(sound, sizeof(sound), "left4fortress/zombie_vo/death_2%d.mp3", GetRandomInt(2, 9));
+					EmitSoundToAll(g_strZombieVO_Common_Death[GetRandomInt(0, sizeof(g_strZombieVO_Common_Death) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 
 				else
 				{
-					int iRandom = GetRandomInt(12, 24);
-					if (iRandom == 15 || iRandom == 16 || iRandom == 17 || iRandom == 23) iRandom = GetRandomInt(12, 14);
-					Format(sound, sizeof(sound), "left4fortress/zombie_vo/been_shot_%d.mp3", iRandom);
+					EmitSoundToAll(g_strZombieVO_Common_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Common_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 			}
 
 			else if (StrContains(sound, "_laugh", false) != -1 || StrContains(sound, "_no", false) != -1 || StrContains(sound, "_yes", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/mumbling0%d.mp3", GetRandomInt(1, 8));
+				EmitSoundToAll(g_strZombieVO_Common_Mumbling[GetRandomInt(0, sizeof(g_strZombieVO_Common_Mumbling) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else if (StrContains(sound, "_go", false) != -1 || StrContains(sound, "_jarate", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/shoved_%d.mp3", GetRandomInt(1, 4));
+				EmitSoundToAll(g_strZombieVO_Common_Shoved[GetRandomInt(0, sizeof(g_strZombieVO_Common_Shoved) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/idle_breath_0%d.mp3", GetRandomInt(1, 4));
+				EmitSoundToAll(g_strZombieVO_Common_Default[GetRandomInt(0, sizeof(g_strZombieVO_Common_Default) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			if (g_iSpecialInfected[iClient] == INFECTED_KINGPIN) pitch = 80;
@@ -5435,18 +5420,18 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 			{
 				if (TF2_IsPlayerInCondition(iClient, TFCond_OnFire))
 				{
-					Format(sound, sizeof(sound), "left4fortress/zombie_vo/tank_fire_0%d.mp3", GetRandomInt(2, 5));
+					EmitSoundToAll(g_strZombieVO_Tank_OnFire[GetRandomInt(0, sizeof(g_strZombieVO_Tank_OnFire) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 
 				else
 				{
-					Format(sound, sizeof(sound), "left4fortress/zombie_vo/tank_pain_0%d.mp3", GetRandomInt(1, 4));
+					EmitSoundToAll(g_strZombieVO_Tank_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 				}
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/tank_voice_0%d.mp3", GetRandomInt(1, 4));
+				EmitSoundToAll(g_strZombieVO_Tank_Default[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Default) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
@@ -5455,12 +5440,12 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/charger_pain_0%d.mp3", GetRandomInt(1, 3));
+				EmitSoundToAll(g_strZombieVO_Charger_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Charger_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/charger_spotprey_0%d.mp3", GetRandomInt(1, 3));
+				EmitSoundToAll(g_strZombieVO_Charger_Default[GetRandomInt(0, sizeof(g_strZombieVO_Charger_Default) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
@@ -5469,12 +5454,12 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/hunter_pain_1%d.mp3", GetRandomInt(2, 4));
+				EmitSoundToAll(g_strZombieVO_Hunter_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Hunter_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/hunter_stalk_0%d.mp3", GetRandomInt(4, 6));
+				EmitSoundToAll(g_strZombieVO_Hunter_Default[GetRandomInt(0, sizeof(g_strZombieVO_Hunter_Default) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
@@ -5483,12 +5468,12 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/male_boomer_pain_%d.mp3", GetRandomInt(1, 3));
+				EmitSoundToAll(g_strZombieVO_Boomer_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Boomer_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/male_boomer_lurk_0%d.mp3", GetRandomInt(2, 4));
+				EmitSoundToAll(g_strZombieVO_Boomer_Default[GetRandomInt(0, sizeof(g_strZombieVO_Boomer_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
@@ -5497,16 +5482,16 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/smoker_pain_0%d.mp3", GetRandomInt(2, 4));
+				EmitSoundToAll(g_strZombieVO_Smoker_Pain[GetRandomInt(0, sizeof(g_strZombieVO_Smoker_Pain) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 
 			else
 			{
-				Format(sound, sizeof(sound), "left4fortress/zombie_vo/smoker_lurk_1%d.mp3", GetRandomInt(1, 3));
+				EmitSoundToAll(g_strZombieVO_Smoker_Default[GetRandomInt(0, sizeof(g_strZombieVO_Smoker_Default) - 1)], iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
 			}
 		}
 
-		return Plugin_Changed;
+		return Plugin_Handled;
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1875,7 +1875,7 @@ public Action event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		int iWinner = 0;
 		float fHighest = 0.0;
 				
-		EmitSoundToAll(g_strZombieVO_Tank_Death[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Death) - 1)], victim, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+		EmitSoundToAll(g_strZombieVO_Tank_Death[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Death) - 1)]);
 				
 		for (int i = 1; i <= MaxClients; i++)
 		{

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1568,6 +1568,8 @@ public Action event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 				SetEntityRenderColor(client, 0, 255, 0, 255);
 				//PerformFastRespawn2(client);
 				
+				EmitSoundToAll(g_strZombieVO_Tank_OnFire[GetRandomInt(0, sizeof(g_strZombieVO_Tank_OnFire) - 1)]);
+				
 				for (int i = 1; i <= MaxClients; i++)
 				{
 					if (IsValidClient(i))
@@ -1591,13 +1593,9 @@ public Action event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 
 						CPrintToChat(i, "{red}Incoming TAAAAANK!");
 						
-						if (GetCurrentSound(i) != SOUND_MUSIC_LASTSTAND || !IsMusicOverrideOn())
+						if (GetCurrentSound(i) != SOUND_MUSIC_LASTSTAND || !IsMusicOverrideOn()) // lms current sound check seems not to work, may need to check it later
 						{
-							PlaySound(i, SOUND_MUSIC_TANK);
-						}
-						else
-						{
-							EmitSoundToAll(g_strZombieVO_Tank_Default[GetRandomInt(0, sizeof(g_strZombieVO_Tank_Default) - 1)]);
+							PlaySound(i, SOUND_MUSIC_TANK);	
 						}
 					}
 

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -5396,7 +5396,7 @@ public Action SoundHook(int clients[64], int &numClients, char sound[PLATFORM_MA
 		{
 			if (StrContains(sound, "_pain", false) != -1)
 			{
-				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1)
+				if (GetClientHealth(iClient) < 50 || StrContains(sound, "crticial", false) != -1) // the typo is intended because that's how the soundfiles are named
 				{
 					Format(sound, sizeof(sound), "left4fortress/zombie_vo/death_2%d.mp3", GetRandomInt(2, 9));
 				}

--- a/addons/sourcemod/scripting/szf/sound.sp
+++ b/addons/sourcemod/scripting/szf/sound.sp
@@ -203,11 +203,11 @@ char g_strSoundSurivourWin[][PLATFORM_MAX_PATH] =
 //Special infected spawned
 char g_strSoundSpawnInfected[][PLATFORM_MAX_PATH] =
 {
-	"ui/null.wav"							//no special infected
-	,"ui/null.wav"							//tank
+	""					//no special infected
+	,""					//tank
 	,"left4fortress/boomerbacterias.mp3"	//boomer
 	,"left4fortress/chargerbacterias.mp3"	//charger
-	,"ui/null.wav"							//kingpin, used to use smoker's bacteria (need new sound for kingpin)
+	,""					//kingpin, used to use smoker's bacteria (need new sound for kingpin)
 	,"left4fortress/jockeybacterias.mp3"	//stalker
 	,"left4fortress/hunterbacterias.mp3"	//hunter
 	,"left4fortress/smokerbacterias.mp3"	//smoker

--- a/addons/sourcemod/scripting/szf/sound.sp
+++ b/addons/sourcemod/scripting/szf/sound.sp
@@ -897,13 +897,13 @@ void EndSound(int iClient)
 		StopSound(iClient, SNDCHAN_AUTO, g_sSound[iClient]);
 	
 	//Reset global variables
-	strcopy(g_sSound[iClient], sizeof(g_sSound), "");
+	strcopy(g_sSound[iClient], sizeof(g_sSound), "misc/null.wav"); //Having nothing here gives an "empty soundpath is not precached" warning to the server every time a music sound stops for each client
 	g_iSound[iClient] = SOUND_NONE;
 }
 
 void GetRandomSound(int iSound, char strPath[PLATFORM_MAX_PATH], int iLength)
 {
-	strcopy(strPath, iLength, "");
+	strcopy(strPath, iLength, "misc/null.wav"); //Having nothing here doesn't seem to matter, but let's keep it consistent
 	
 	switch (iSound)
 	{

--- a/addons/sourcemod/scripting/szf/sound.sp
+++ b/addons/sourcemod/scripting/szf/sound.sp
@@ -203,11 +203,11 @@ char g_strSoundSurivourWin[][PLATFORM_MAX_PATH] =
 //Special infected spawned
 char g_strSoundSpawnInfected[][PLATFORM_MAX_PATH] =
 {
-	""					//no special infected
-	,""					//tank
+	"misc/null.wav"				//no special infected
+	,"misc/null.wav"			//tank
 	,"left4fortress/boomerbacterias.mp3"	//boomer
 	,"left4fortress/chargerbacterias.mp3"	//charger
-	,""					//kingpin, used to use smoker's bacteria (need new sound for kingpin)
+	,"misc/null.wav"			//kingpin, used to use smoker's bacteria (need new sound for kingpin)
 	,"left4fortress/jockeybacterias.mp3"	//stalker
 	,"left4fortress/hunterbacterias.mp3"	//hunter
 	,"left4fortress/smokerbacterias.mp3"	//smoker

--- a/addons/sourcemod/scripting/szf/sound.sp
+++ b/addons/sourcemod/scripting/szf/sound.sp
@@ -203,15 +203,17 @@ char g_strSoundSurivourWin[][PLATFORM_MAX_PATH] =
 //Special infected spawned
 char g_strSoundSpawnInfected[][PLATFORM_MAX_PATH] =
 {
-	""										//no special infected
-	,""										//tank
+	"ui/null.wav"							//no special infected
+	,"ui/null.wav"							//tank
 	,"left4fortress/boomerbacterias.mp3"	//boomer
 	,"left4fortress/chargerbacterias.mp3"	//charger
-	,""										//kingpin, used to use smoker's bacteria (need new sound for kingpin)
+	,"ui/null.wav"							//kingpin, used to use smoker's bacteria (need new sound for kingpin)
 	,"left4fortress/jockeybacterias.mp3"	//stalker
 	,"left4fortress/hunterbacterias.mp3"	//hunter
 	,"left4fortress/smokerbacterias.mp3"	//smoker
 };
+
+/* VO */
 
 /* SOLDIER */
 char g_strCarryVO_Soldier[][PLATFORM_MAX_PATH] =
@@ -413,97 +415,187 @@ char g_strWeaponVO_Sniper[][PLATFORM_MAX_PATH] =
     ,"vo/sniper_specialweapon09.mp3"
 };
 
-char g_strZombieVO[][PLATFORM_MAX_PATH] =
+/* Common Infected */
+char g_strZombieVO_Common_Default[][PLATFORM_MAX_PATH] =
 {
-    "been_shot_12"
-    ,"been_shot_13"
-    ,"been_shot_14"
-    ,"been_shot_18"
-    ,"been_shot_19"
-    ,"been_shot_20"
-    ,"been_shot_21"
-    ,"been_shot_22"
-    ,"been_shot_24"
-    ,"charger_charge_01"
-    ,"charger_charge_02"
-    ,"charger_pain_01"
-    ,"charger_pain_02"
-    ,"charger_pain_03"
-    ,"charger_spotprey_01"
-    ,"charger_spotprey_02"
-    ,"charger_spotprey_03"
-    ,"death_22"
-    ,"death_23"
-    ,"death_24"
-    ,"death_25"
-    ,"death_26"
-    ,"death_27"
-    ,"death_28"
-    ,"death_29"
-    ,"hunter_attackmix_01"
-    ,"hunter_attackmix_02"
-    ,"hunter_attackmix_03"
-    ,"hunter_pain_12"
-    ,"hunter_pain_13"
-    ,"hunter_pain_14"
-    ,"hunter_stalk_04"
-    ,"hunter_stalk_05"
-    ,"hunter_stalk_06"
-    ,"idle_breath_01"
-    ,"idle_breath_02"
-    ,"idle_breath_03"
-    ,"idle_breath_04"
-    ,"male_boomer_disruptvomit_05"
-    ,"male_boomer_disruptvomit_06"
-    ,"male_boomer_disruptvomit_07"
-    ,"male_boomer_lurk_02"
-    ,"male_boomer_lurk_03"
-    ,"male_boomer_lurk_04"
-    ,"male_boomer_pain_1"
-    ,"male_boomer_pain_2"
-    ,"male_boomer_pain_3"
-    ,"mumbling01"
-    ,"mumbling02"
-    ,"mumbling03"
-    ,"mumbling04"
-    ,"mumbling05"
-    ,"mumbling06"
-    ,"mumbling07"
-    ,"mumbling08"
-    ,"rage_at_victim21"
-    ,"rage_at_victim22"
-    ,"rage_at_victim25"
-    ,"rage_at_victim26"
-    ,"shoved_1"
-    ,"shoved_2"
-    ,"shoved_3"
-    ,"shoved_4"
-    ,"smoker_lurk_11"
-    ,"smoker_lurk_12"
-    ,"smoker_lurk_13"
-    ,"smoker_pain_02"
-    ,"smoker_pain_03"
-    ,"smoker_pain_04"
-    ,"tank_attack_01"
-    ,"tank_attack_02"
-    ,"tank_attack_03"
-    ,"tank_attack_04"
-    ,"tank_death_01"
-    ,"tank_death_02"
-    ,"tank_death_03"
-    ,"tank_death_04"
-    ,"tank_fire_02"
-    ,"tank_fire_03"
-    ,"tank_fire_04"
-    ,"tank_fire_05"
-    ,"tank_pain_01"
-    ,"tank_pain_02"
-    ,"tank_pain_03"
-    ,"tank_pain_04"
-    ,"tank_voice_01"
-    ,"tank_voice_02"
-    ,"tank_voice_03"
-    ,"tank_voice_04"
+    "left4fortress/zombie_vo/idle_breath_01.mp3"
+    ,"left4fortress/zombie_vo/idle_breath_02.mp3"
+    ,"left4fortress/zombie_vo/idle_breath_03.mp3"
+    ,"left4fortress/zombie_vo/idle_breath_04.mp3"
+};
+
+char g_strZombieVO_Common_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/been_shot_12.mp3"
+    ,"left4fortress/zombie_vo/been_shot_13.mp3"
+    ,"left4fortress/zombie_vo/been_shot_14.mp3"
+    ,"left4fortress/zombie_vo/been_shot_18.mp3"
+    ,"left4fortress/zombie_vo/been_shot_19.mp3"
+    ,"left4fortress/zombie_vo/been_shot_20.mp3"
+    ,"left4fortress/zombie_vo/been_shot_21.mp3"
+    ,"left4fortress/zombie_vo/been_shot_22.mp3"
+    ,"left4fortress/zombie_vo/been_shot_24.mp3"
+};
+
+char g_strZombieVO_Common_Rage[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/rage_at_victim21.mp3"
+    ,"left4fortress/zombie_vo/rage_at_victim22.mp3"
+    ,"left4fortress/zombie_vo/rage_at_victim25.mp3"
+    ,"left4fortress/zombie_vo/rage_at_victim26.mp3"
+};
+
+char g_strZombieVO_Common_Mumbling[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/mumbling01.mp3"
+    ,"left4fortress/zombie_vo/mumbling02.mp3"
+    ,"left4fortress/zombie_vo/mumbling03.mp3"
+    ,"left4fortress/zombie_vo/mumbling04.mp3"
+    ,"left4fortress/zombie_vo/mumbling05.mp3"
+    ,"left4fortress/zombie_vo/mumbling06.mp3"
+    ,"left4fortress/zombie_vo/mumbling07.mp3"
+    ,"left4fortress/zombie_vo/mumbling08.mp3"
+};
+
+char g_strZombieVO_Common_Shoved[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/shoved_1.mp3"
+    ,"left4fortress/zombie_vo/shoved_2.mp3"
+    ,"left4fortress/zombie_vo/shoved_3.mp3"
+    ,"left4fortress/zombie_vo/shoved_4.mp3"
+};
+
+char g_strZombieVO_Common_Death[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/death_22.mp3"
+    ,"left4fortress/zombie_vo/death_23.mp3"
+    ,"left4fortress/zombie_vo/death_24.mp3"
+    ,"left4fortress/zombie_vo/death_25.mp3"
+    ,"left4fortress/zombie_vo/death_26.mp3"
+    ,"left4fortress/zombie_vo/death_27.mp3"
+    ,"left4fortress/zombie_vo/death_28.mp3"
+    ,"left4fortress/zombie_vo/death_29.mp3"
+};
+
+/* Boomer */
+char g_strZombieVO_Boomer_Default[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/male_boomer_lurk_02.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_lurk_03.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_lurk_04.mp3"
+};
+
+char g_strZombieVO_Boomer_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/male_boomer_pain_1.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_pain_2.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_pain_3.mp3"
+};
+
+char g_strZombieVO_Boomer_Explode[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/male_boomer_disruptvomit_05.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_disruptvomit_06.mp3"
+    ,"left4fortress/zombie_vo/male_boomer_disruptvomit_07.mp3"
+};
+
+/* Charger */
+char g_strZombieVO_Charger_Default[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/charger_spotprey_01.mp3"
+    ,"left4fortress/zombie_vo/charger_spotprey_02.mp3"
+    ,"left4fortress/zombie_vo/charger_spotprey_03.mp3"
+};
+
+char g_strZombieVO_Charger_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/charger_pain_01.mp3"
+    ,"left4fortress/zombie_vo/charger_pain_02.mp3"
+    ,"left4fortress/zombie_vo/charger_pain_03.mp3"
+};
+
+char g_strZombieVO_Charger_Charge[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/charger_charge_01.mp3"
+    ,"left4fortress/zombie_vo/charger_charge_02.mp3"
+};
+
+/* Hunter */
+char g_strZombieVO_Hunter_Default[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/hunter_stalk_04.mp3"
+    ,"left4fortress/zombie_vo/hunter_stalk_05.mp3"
+    ,"left4fortress/zombie_vo/hunter_stalk_06.mp3"
+};
+
+char g_strZombieVO_Hunter_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/hunter_pain_12.mp3"
+    ,"left4fortress/zombie_vo/hunter_pain_13.mp3"
+    ,"left4fortress/zombie_vo/hunter_pain_14.mp3"
+};
+
+char g_strZombieVO_Hunter_Leap[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/hunter_attackmix_01.mp3"
+    ,"left4fortress/zombie_vo/hunter_attackmix_02.mp3"
+    ,"left4fortress/zombie_vo/hunter_attackmix_03.mp3"
+};
+
+/* Smoker */
+char g_strZombieVO_Smoker_Default[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/smoker_lurk_11.mp3"
+    ,"left4fortress/zombie_vo/smoker_lurk_12.mp3"
+    ,"left4fortress/zombie_vo/smoker_lurk_13.mp3"
+};
+
+char g_strZombieVO_Smoker_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/smoker_pain_02.mp3"
+    ,"left4fortress/zombie_vo/smoker_pain_03.mp3"
+    ,"left4fortress/zombie_vo/smoker_pain_04.mp3"
+};
+
+/* Tank */
+char g_strZombieVO_Tank_Default[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/tank_voice_01.mp3"
+    ,"left4fortress/zombie_vo/tank_voice_02.mp3"
+    ,"left4fortress/zombie_vo/tank_voice_03.mp3"
+    ,"left4fortress/zombie_vo/tank_voice_04.mp3"
+};
+
+char g_strZombieVO_Tank_Pain[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/tank_pain_01.mp3"
+    ,"left4fortress/zombie_vo/tank_pain_02.mp3"
+    ,"left4fortress/zombie_vo/tank_pain_03.mp3"
+    ,"left4fortress/zombie_vo/tank_pain_04.mp3"
+};
+
+char g_strZombieVO_Tank_OnFire[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/tank_fire_02.mp3"
+    ,"left4fortress/zombie_vo/tank_fire_03.mp3"
+    ,"left4fortress/zombie_vo/tank_fire_04.mp3"
+    ,"left4fortress/zombie_vo/tank_fire_05.mp3"
+};
+
+char g_strZombieVO_Tank_Attack[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/tank_attack_01.mp3"
+    ,"left4fortress/zombie_vo/tank_attack_02.mp3"
+    ,"left4fortress/zombie_vo/tank_attack_03.mp3"
+    ,"left4fortress/zombie_vo/tank_attack_04.mp3"
+};
+
+char g_strZombieVO_Tank_Death[][PLATFORM_MAX_PATH] =
+{
+    "left4fortress/zombie_vo/tank_death_01.mp3"
+    ,"left4fortress/zombie_vo/tank_death_02.mp3"
+    ,"left4fortress/zombie_vo/tank_death_03.mp3"
+    ,"left4fortress/zombie_vo/tank_death_04.mp3"
 };
 
 void SoundPrecache()
@@ -558,13 +650,36 @@ void SoundPrecache()
 	
 	for (int i = 0; i < sizeof(g_strCarryVO_Sniper); i++) PrecacheSound(g_strCarryVO_Sniper[i]);
 	for (int i = 0; i < sizeof(g_strWeaponVO_Sniper); i++) PrecacheSound(g_strWeaponVO_Sniper[i]);
-	
-	for (int i = 0; i < sizeof(g_strZombieVO); i++)
-    {
-        char strPath[96];
-        Format(strPath, sizeof(strPath), "left4fortress/zombie_vo/%s.mp3", g_strZombieVO[i]);
-        PrecacheSound2(strPath);
-    }
+    
+    //---//
+    
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Default); i++) PrecacheSound2(g_strZombieVO_Common_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Pain); i++) PrecacheSound2(g_strZombieVO_Common_Pain[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Rage); i++) PrecacheSound2(g_strZombieVO_Common_Rage[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Mumbling); i++) PrecacheSound2(g_strZombieVO_Common_Mumbling[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Shoved); i++) PrecacheSound2(g_strZombieVO_Common_Shoved[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Common_Death); i++) PrecacheSound2(g_strZombieVO_Common_Death[i]);
+
+	for (int i = 0; i < sizeof(g_strZombieVO_Boomer_Default); i++) PrecacheSound2(g_strZombieVO_Boomer_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Boomer_Pain); i++) PrecacheSound2(g_strZombieVO_Boomer_Pain[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Boomer_Explode); i++) PrecacheSound2(g_strZombieVO_Boomer_Explode[i]);
+
+	for (int i = 0; i < sizeof(g_strZombieVO_Charger_Default); i++) PrecacheSound2(g_strZombieVO_Charger_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Charger_Pain); i++) PrecacheSound2(g_strZombieVO_Charger_Pain[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Charger_Charge); i++) PrecacheSound2(g_strZombieVO_Charger_Charge[i]);
+
+	for (int i = 0; i < sizeof(g_strZombieVO_Hunter_Default); i++) PrecacheSound2(g_strZombieVO_Hunter_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Hunter_Pain); i++) PrecacheSound2(g_strZombieVO_Hunter_Pain[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Hunter_Leap); i++) PrecacheSound2(g_strZombieVO_Hunter_Leap[i]);
+
+	for (int i = 0; i < sizeof(g_strZombieVO_Smoker_Default); i++) PrecacheSound2(g_strZombieVO_Smoker_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Smoker_Pain); i++) PrecacheSound2(g_strZombieVO_Smoker_Pain[i]);
+
+	for (int i = 0; i < sizeof(g_strZombieVO_Tank_Default); i++) PrecacheSound2(g_strZombieVO_Tank_Default[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Tank_Pain); i++) PrecacheSound2(g_strZombieVO_Tank_Pain[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Tank_OnFire); i++) PrecacheSound2(g_strZombieVO_Tank_OnFire[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Tank_Attack); i++) PrecacheSound2(g_strZombieVO_Tank_Attack[i]);
+	for (int i = 0; i < sizeof(g_strZombieVO_Tank_Death); i++) PrecacheSound2(g_strZombieVO_Tank_Death[i]);
 }
 
 stock void PrecacheSound2(const char[] sSoundPath)


### PR DESCRIPTION
(this was just for VO, but it escalated as it went on)

This PR looks into a few issues:
- There was a lot of infected VO that was unintentionally unused, yet precached, all of them will be made use of.
- The gamemode would give a lot of "blank sound not precached" warnings to the server console, most of them will be stopped (only exception is the first music bit a client hears after the gamemode has been loaded)
- Bacteria (special infected global callout) didn't play correctly, it will be fixed for classes that unintentionally didn't make use of it.

Changes:

**VO:**
Regular infected:
 - all stock-voiceline-specific sounds work properly. Before, the only different (as in, not idle) infected voiceline that would play was to call for Medic while taunting, most of it was because the code was blocking itself from playing certain sounds because there is `vo/` in `zombie_vo/`. This includes: raging, using "yes," "no" and "go go go" voice commands, laughing, getting jarate'd, getting hurt, dying.
 - removed "ignite" VO, as it does not exist.
 - raging no longer tries to play a battlecry since there already is custom VO for that.

Special infected:
 - Charger now plays charging VO.
 - Boomer now plays exploding VO.
 - Hunter now plays leaping VO.
 - Tank now plays attacking and spawning VO.

**Bacteria:**
- Boomer now plays its bacteria sound effect.
- Charger now plays its bacteria sound effect.
- Hunter now plays its bacteria sound effect.
