### PR TITLE
Update Voodoo models to not require tf2items

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ Sourcemod 1.10 or higher is required for servers to use this plugin, as it uses 
 - [tf_econ_data](https://forums.alliedmods.net/showthread.php?t=315011)
 - [dhooks](https://forums.alliedmods.net/showthread.php?t=180114)
 - [morecolors](https://forums.alliedmods.net/showthread.php?t=185016) (Only needed if recompiling)
-
-# Optional Plugin/Extension Dependencies
-
-- [tf2items](https://forums.alliedmods.net/showthread.php?t=115100) (Applying voodoo-cursed souls)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -16,10 +16,6 @@
 
 #include "include/superzombiefortress.inc"
 
-#undef REQUIRE_EXTENSIONS
-#tryinclude <tf2items>
-#define REQUIRE_EXTENSIONS
-
 #pragma newdecls required
 
 #define PLUGIN_VERSION "3.1.2"
@@ -29,8 +25,6 @@
 #define MAX_DIGITS 	12 // 10 + \0 for IntToString. And negative signs.
 
 #define GOO_INCREASE_RATE		3
-
-bool bTF2Items = true;
 
 Handle cookieFirstTimeSurvivor;
 Handle cookieFirstTimeZombie;
@@ -269,16 +263,6 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("SZF_GetWeaponCalloutCount", Native_GetWeaponCalloutCount);
 	
 	RegPluginLibrary("superzombiefortress");
-}
-
-public void OnAllPluginsLoaded()
-{
-	// tf2items
-	if (GetExtensionFileStatus("tf2items.ext") != 1)
-	{
-		bTF2Items = false;
-		LogMessage("TF2Items is not loaded: Zombies will not receive voodoo cursed souls from the plugin.");
-	}
 }
 
 public void OnPluginStart()


### PR DESCRIPTION
New method to create/equip Voodoo models is similar to how my VSH-Rewrite is done, using `TF2_CreateAndEquipWeapon` stock to create wearable and entprop `m_nModelIndexOverrides` to get model correctly. Even though it not really a weapon, it still somehow works for wearable aswell.

Also changed index of wearable from 5023 (paint can) to correct index for each 9 voodoo cosmetics. This doesn't really make much difference, but inspecting cosmetics while dead/spectator now shows voodoo instead of paint can.