### PR TITLE
Fix Back Scratcher not having the 90% healing received from healers penalty

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -433,7 +433,7 @@
 		"326"	//Back Scratcher
 		{
 			"text"		"{orange}The Back Scratcher {red}has a 90% health from healers penalty."
-			"attrib"	"69 ; 0.9"
+			"attrib"	"69 ; 0.1"
 		}
 		"155"	//Southern Hospitality
 		{


### PR DESCRIPTION
The attribute was there, but its value was wrong (was at 10%).

Fix for issue #30.