### PR TITLE
Remove survivors 1st round buff

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1407,26 +1407,9 @@ void EndGracePeriod()
 
 	int iSurvivors = GetSurvivorCount();
 	int iZombies = GetZombieCount();
-	int iConnecting = GetConnectingCount();
 
-	// buff survivors if these conditions are met:
-	// first round
-	// 16 or more people are still connecting
-	// 4 survivors or less are in the team
-	if (g_bFirstRound && iConnecting >= 16 && iSurvivors <= 4)
-	{
-		// for loop
-		for (int i = 1; i <= MaxClients; i++)
-		{
-			if (IsValidLivingSurvivor(i))
-				SetEntityHealth(i, 300);
-			
-			if (IsClientInGame(i))
-				CPrintToChat(i, "%sSurvivors have received extra health due to being in a heavy disadvantage in the first round.", (IsZombie(i)) ? "{red}" : "{green}");
-		}
-	}
-
-	else if (float(iZombies) / float(iSurvivors + iZombies) <= 0.15)	//If less than 15% of players is zombie, give buff
+	//If less than 15% of players is zombie, give buff
+	if (float(iZombies) / float(iSurvivors + iZombies) <= 0.15)
 	{
 		// for loop
 		for (int i = 1; i <= MaxClients; i++)


### PR DESCRIPTION
Currently in 1st round, if 4 or less survivors and more than 16 connecting players, all survivors get 300 starting health.

Since there a +60 seconds setup, it quite rare to see this happens only for starting health. Along with that, "new" zombie damage scale is already fairly low during early-game with low survivors and high zombies. There isn't really any point keeping it.