### PR TITLE
Kill DealDamage, use SDKHooks_TakeDamage instead

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -2577,22 +2577,21 @@ void handle_gameFrameLogic()
 				float flDistance;
 				GetClientEyePosition(i, flPosCharger);
 
-				for (int z = 1; z <= MaxClients; z++)
+				for (int iVictim = 1; iVictim <= MaxClients; iVictim++)
 				{
-					int iVictim = z;
 					if (IsClientInGame(iVictim) && IsPlayerAlive(iVictim) && IsSurvivor(iVictim))
 					{
-						GetClientEyePosition(z, flPosClient);
+						GetClientEyePosition(iVictim, flPosClient);
 						flDistance = GetVectorDistance(flPosCharger, flPosClient);
 						if (flDistance <= 95.0)
 						{
-							if (!g_bBackstabbed[z])
+							if (!g_bBackstabbed[iVictim])
 							{
-								SetEntityHealth(iVictim, GetClientHealth(iVictim) - 30);
-								TF2_MakeBleed(iVictim, i, 2.0);
-
 								SetBackstabState(iVictim, BACKSTABDURATION_FULL, 0.8);
 								SetNextAttack(i, GetGameTime() + 0.6);
+								
+								TF2_MakeBleed(iVictim, i, 2.0);
+								SDKHooks_TakeDamage(iVictim, i, i, 30.0, DMG_PREVENT_PHYSICS_FORCE);
 
 								char strPath[PLATFORM_MAX_PATH];
 								Format(strPath, sizeof(strPath), "weapons/demo_charge_hit_flesh_range1.wav", GetRandomInt(1, 3));
@@ -2605,7 +2604,6 @@ void handle_gameFrameLogic()
 							}
 
 							TF2_RemoveCondition(i, TFCond_Charging);
-							DealDamage(z, 1, i, _, "tf_wearable_demoshield");
 							break; // target found, break the loop.
 						}
 					}
@@ -4560,8 +4558,7 @@ void GooDamageCheck()
 						float fDamage = float(g_iGooMultiplier[iClient])/float(GOO_INCREASE_RATE) * fPercentageDistance;
 						if (fDamage < 1.0) fDamage = 1.0;
 						if (fDamage > 4.0 && zf_CapturingPoint[iClient] != -1) fDamage = 4.0;	//If client is capturing point, add hardmax 4 dmg
-						int iDamage = RoundFloat(fDamage);
-						DealDamage(iClient, iDamage, iAttacker, _, "projectile_stun_ball");
+						SDKHooks_TakeDamage(iClient, iAttacker, iAttacker, fDamage, DMG_PREVENT_PHYSICS_FORCE);
 						g_bGooified[iClient] = true;
 
 						if (fDamage >= 7.0)
@@ -4844,7 +4841,7 @@ public Action OnSandvichTouch(int iEntity, int iClient)
 		SetEntProp(iEntity, Prop_Data, "m_bDisabled", 1);
 		AcceptEntityInput(iEntity, "Kill");
 
-		DealDamage(iToucher, 55, iOwner);
+		SDKHooks_TakeDamage(iToucher, iOwner, iOwner, 55.0);
 
 		return Plugin_Handled;
 	}
@@ -4869,7 +4866,7 @@ public Action OnBananaTouch(int iEntity, int iClient)
 		SetEntProp(iEntity, Prop_Data, "m_bDisabled", 1);
 		AcceptEntityInput(iEntity, "Kill");
 
-		DealDamage(iToucher, 30, iOwner);
+		SDKHooks_TakeDamage(iToucher, iOwner, iOwner, 30.0);
 
 		return Plugin_Handled;
 	}
@@ -5890,7 +5887,7 @@ public void DoSmokerBeam(int iClient)
 		g_iSmokerBeamHits[iClient]++;
 		if (g_iSmokerBeamHits[iClient] == 5)
 		{
-			DealDamage(iHit, 2, iClient); // do damage
+			SDKHooks_TakeDamage(iHit, iClient, iClient, 2.0, DMG_PREVENT_PHYSICS_FORCE); // do damage
 			g_iSmokerBeamHits[iClient] = 0;
 		}
 

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -721,37 +721,6 @@ stock void setTeamRespawnTime(int team, float time)
 
 ////////////////////////////////////////////////////////////
 //
-// Damage Utils
-//
-////////////////////////////////////////////////////////////
-stock void DealDamage(int iVictim, int iDamage, int iAttacker = 0, int iDmgType = DMG_GENERIC, char[] strWeapon = "")
-{
-	if (!IsValidClient(iAttacker)) iAttacker = 0;
-	if (IsValidClient(iVictim) && iDamage > 0)
-	{
-		char strDamage[16];
-		IntToString(iDamage, strDamage, 16);
-		char strDamageType[32];
-		IntToString(iDmgType, strDamageType, 32);
-		int iHurt = CreateEntityByName("point_hurt");
-		if (iHurt > 0 && IsValidEdict(iHurt))
-		{
-			DispatchKeyValue(iVictim, "targetname", "infectious_hurtme");
-			DispatchKeyValue(iHurt, "DamageTarget", "infectious_hurtme");
-			DispatchKeyValue(iHurt, "Damage", strDamage);
-			DispatchKeyValue(iHurt, "DamageType", strDamageType);
-			if (!StrEqual(strWeapon, "")) DispatchKeyValue(iHurt, "classname", strWeapon);
-			DispatchSpawn(iHurt);
-			AcceptEntityInput(iHurt, "Hurt", iAttacker);
-			DispatchKeyValue(iHurt, "classname", "point_hurt");
-			DispatchKeyValue(iVictim, "targetname", "infectious_donthurtme");
-			RemoveEdict(iHurt);
-		}
-	}
-}
-
-////////////////////////////////////////////////////////////
-//
 // Weapon Utils
 //
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Every time `DealDamage` get called, it spawns an entity while also dispatching quite a few values to deal damage, not a nice method to do when `SDKHooks_TakeDamage` works much simpler and faster.