### PR TITLE
Add valid attacker check for goo damage

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -4576,8 +4576,11 @@ void GooDamageCheck()
 			fPosGoo[0] = float(iEntry[0]);
 			fPosGoo[1] = float(iEntry[1]);
 			fPosGoo[2] = float(iEntry[2]);
+			
 			iAttacker = iEntry[3];
-
+			if (!IsValidClient(iAttacker))
+				continue;
+			
 			for (iClient = 1; iClient <= MaxClients; iClient++)
 			{
 				if (IsValidLivingSurvivor(iClient) && !g_bGooified[iClient] && CanRecieveDamage(iClient) && !g_bBackstabbed[iClient])


### PR DESCRIPTION
Error has been thrown from `SDKHooks_TakeDamage` on invalid attacker, since there was no check for it.