### PR TITLE
Make crit-a-cola and steak not a near complete downgrade

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -832,7 +832,7 @@ public Action OnTakeDamage(int iVictim, int &iAttacker, int &iInflicter, float &
 				|| TF2_IsPlayerInCondition(iAttacker, TFCond_CritHype))
 			{
 				// reduce damage from crit amplifying items when active
-				fDamage *= 0.66;
+				fDamage *= 0.85;
 				bChanged = true;
 			}
 

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -943,7 +943,7 @@ public Action OnTakeDamage(int iVictim, int &iAttacker, int &iInflicter, float &
 					|| TF2_IsPlayerInCondition(iVictim, TFCond_CritHype))
 				{
 					// increase damage taken from crit amplifying items when active
-					fDamage *= 1.5;
+					fDamage *= 1.1;
 					bChanged = true;
 				}
 			}

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -435,7 +435,6 @@ stock float clientBonusSpeed(int client)
 		//
 		// Handle heavy bonuses
 		// + Wielding GRU
-		// + Affected by Steak or similar
 		//
 		case TFClass_Heavy:
 		{
@@ -443,12 +442,13 @@ stock float clientBonusSpeed(int client)
 			{
 				return 70.0;
 			}
-
+			/*
 			else if (TF2_IsPlayerInCondition(client, TFCond_CritCola))
 			{
 				//return 40.0;
 				return 20.0;
 			}
+			*/
 		}
 	}
 


### PR DESCRIPTION
Previously, using crit-a-cola or steak lowers damage dealt much less. Infact even less damage than minicrit bonus, ending up your total damage dealt less than not using it. This plus taking even more damage while under effect, not worth it for just a +20hu speed bonus. After a few talks, we now have a new math.

**The new math**
Crit-a-cola:
- Damage dealt now increased by 1.1475x, making scout's average damage dealt increased from 21dmg to 25dmg
- Damage taken now increased by 1.485x if marked for death, making scout's average health reduce from 125hp to 84hp

Buffalo Steak:
- Damage dealt now increased by 1.1475x, making heavy's average damage dealt increased from 46dmg to 52dmg
- Damage taken now increased by 1.32x, making heavy's average health reduce from 300hp to 227hp

Adding from steak, +20hu speed bonus removed. 52dmg plus +60hu speed while overheal & frenzy is already a bit too much.