### PR TITLE
Fix legacy enum struct compile warning

### DIFF
--- a/addons/sourcemod/scripting/szf/weapons.sp
+++ b/addons/sourcemod/scripting/szf/weapons.sp
@@ -1,7 +1,7 @@
 typedef eWeapon_OnPickup = function bool (int client); // Return false to prevent client from picking up the item.
 
 static ArrayList g_Weapons;
-static ArrayList g_WepIndexesByRarity[eWeaponsRarity]; // Array indexes of g_Weapons array
+static ArrayList g_WepIndexesByRarity[view_as<int>(eWeaponsRarity)]; // Array indexes of g_Weapons array
 static StringMap g_WeaponsReskin;
 
 enum struct eWeapon


### PR DESCRIPTION
SourcePawn 1.10 had an update, warns about legacy enum struct removed in 1.11.

While `eWeaponsRarity` may doesn't look like legacy enum struct, it actually an array of int, which what makes it an enum struct.