### PR TITLE
Disallow players from joining the infected team during grace period/setup

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1062,9 +1062,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			
 			// Prevent joining any other team.
 			else
-			{
 				return Plugin_Handled;
-			}
 		}
 		
 		else if (roundState() > RoundGrace)
@@ -1082,15 +1080,11 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			// If client tries to join the zombie team or spectator
 			// during grace period or active round, let them do so.
 			else if (StrEqual(cmd1, sZomTeam, false) || StrEqual(cmd1, "spectate", false))
-			{
 				return Plugin_Continue;
-			}
 			
 			// Prevent joining any other team.
 			else
-			{
 				return Plugin_Handled;
-			}
 		}
 	}
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1052,7 +1052,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			// deny and set them as infected instead.
 			else if (StrEqual(cmd1, sSurTeam, false))
 			{
-				if (GetClientTeam(client) <= 1)
+				if (GetClientTeam(client) <= 1 && !g_bWaitingForTeamSwitch[client])
 				{
 					CPrintToChat(client, "{red}Can not join the Survivor team at this time. You will join the Infected team when grace period ends.");
 					g_bWaitingForTeamSwitch[client] = true;

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1019,7 +1019,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			if (StrEqual(cmd1, sZomTeam, false) || StrEqual(cmd1, "auto", false) || StrEqual(cmd1, "autoteam", false))
 			{
 				// ...as survivor, don't let them.
-				if (iTeam == 2)
+				if (iTeam == surTeam())
 				{
 					CPrintToChat(client, "{red}You can not switch to the opposing team during grace period.");
 					return Plugin_Handled;
@@ -1030,7 +1030,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 				{
 					if (!g_bWaitingForTeamSwitch[client])
 					{
-						if (iTeam == 0) // If they're unassigned, let them spectate for now.
+						if (iTeam == INT(TFTeam_Unassigned)) // If they're unassigned, let them spectate for now.
 							ChangeClientTeam(client, INT(TFTeam_Spectator));
 							
 						CPrintToChat(client, "{red}You will join the Infected team when grace period ends.");
@@ -1067,7 +1067,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 					}
 					else
 					{
-						if (iTeam == 0) // If they're unassigned, let them spectate for now.
+						if (iTeam == INT(TFTeam_Unassigned)) // If they're unassigned, let them spectate for now.
 							ChangeClientTeam(client, INT(TFTeam_Spectator));
 							
 						CPrintToChat(client, "{red}Can not join the Survivor team at this time. You will join the Infected team when grace period ends.");

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1008,6 +1008,8 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 		sZomTeam = "red";
 		sZomVgui = "class_red";
 	}
+	
+	int iTeam = GetClientTeam(client);
 
 	if (IsClientInGame(client))
 	{
@@ -1024,10 +1026,13 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 				}
 
 				// ...as a spectator who didn't start as an infected, set them as infected after grace period ends, after warning them.
-				if (GetClientTeam(client) <= 1 && !g_bStartedAsZombie[client])
+				if (iTeam <= 1 && !g_bStartedAsZombie[client])
 				{
 					if (!g_bWaitingForTeamSwitch[client])
 					{
+						if (iTeam == 0) // If they're unassigned, let them spectate for now.
+							ChangeClientTeam(client, INT(TFTeam_Spectator));
+							
 						CPrintToChat(client, "{red}You will join the Infected team when grace period ends.");
 						g_bWaitingForTeamSwitch[client] = true;
 					}
@@ -1040,8 +1045,8 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			// it before.
 			else if (StrEqual(cmd1, "spectate", false))
 			{
-				if (GetClientTeam(client) <= 1 && g_bWaitingForTeamSwitch[client])
-				{
+				if (iTeam <= 1 && g_bWaitingForTeamSwitch[client])
+				{					
 					CPrintToChat(client, "{red}You will no longer automatically join the Infected team when grace period ends.");
 					g_bWaitingForTeamSwitch[client] = false;
 				}
@@ -1052,7 +1057,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			// deny and set them as infected instead.
 			else if (StrEqual(cmd1, sSurTeam, false))
 			{
-				if (GetClientTeam(client) <= 1 && !g_bWaitingForTeamSwitch[client])
+				if (iTeam <= 1 && !g_bWaitingForTeamSwitch[client])
 				{
 					// However, if they started as infected, they can spawn as infected again, normally.
 					if (g_bStartedAsZombie[client])
@@ -1062,6 +1067,9 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 					}
 					else
 					{
+						if (iTeam == 0) // If they're unassigned, let them spectate for now.
+							ChangeClientTeam(client, INT(TFTeam_Spectator));
+							
 						CPrintToChat(client, "{red}Can not join the Survivor team at this time. You will join the Infected team when grace period ends.");
 						g_bWaitingForTeamSwitch[client] = true;
 					}

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1008,18 +1008,18 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 		sZomTeam = "red";
 		sZomVgui = "class_red";
 	}
-	
-	int iTeam = GetClientTeam(client);
 
 	if (IsClientInGame(client))
 	{
 		if (roundState() == RoundGrace)
 		{
+			int iTeam = GetClientTeam(client);
+		
 			// If a client tries to join the infected team or a random team during grace period...
 			if (StrEqual(cmd1, sZomTeam, false) || StrEqual(cmd1, "auto", false) || StrEqual(cmd1, "autoteam", false))
 			{
 				// ...as survivor, don't let them.
-				if (IsSurvivor(client))
+				if (iTeam == 2)
 				{
 					CPrintToChat(client, "{red}You can not switch to the opposing team during grace period.");
 					return Plugin_Handled;

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -51,7 +51,7 @@ bool zf_screamerNearby[MAXPLAYERS+1] = false;
 
 bool g_bStartedAsZombie[MAXPLAYERS+1];
 float g_flStopChatSpam[MAXPLAYERS+1] = 0.0;
-bool g_bWaitingForTeamSwitch[MAXPLAYERS + 1] = false;
+bool g_bWaitingForTeamSwitch[MAXPLAYERS+1];
 
 int g_iSprite; // Smoker beam
 
@@ -981,7 +981,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 
 	if (!zf_bEnabled) return Plugin_Continue;
 	if (argc < 1 && StrEqual(command, "jointeam", false)) return Plugin_Handled;
-	if (roundState() < RoundGrace) return Plugin_Handled;
+	if (roundState() < RoundGrace) return Plugin_Continue;
 	
 	//Get command/arg on which team player joined
 	if (StrEqual(command, "jointeam", false)) // this is done because "jointeam spectate" should take priority over "spectate"

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1068,7 +1068,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 		else if (roundState() > RoundGrace)
 		{
 			// If client tries to join the survivor team or a random team
-			// during grace period or active round, place them on the zombie
+			// during an active round, place them on the zombie
 			// team and present them with the zombie class select screen.
 			if (StrEqual(cmd1, sSurTeam, false) || StrEqual(cmd1, "auto", false))
 			{
@@ -1078,7 +1078,7 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 			}
 			
 			// If client tries to join the zombie team or spectator
-			// during grace period or active round, let them do so.
+			// during an active round, let them do so.
 			else if (StrEqual(cmd1, sZomTeam, false) || StrEqual(cmd1, "spectate", false))
 				return Plugin_Continue;
 			
@@ -1476,7 +1476,7 @@ void EndGracePeriod()
 	int iSurvivors = GetSurvivorCount();
 	int iZombies = GetZombieCount();
 
-	//If less than 15% of players is zombie, set round start as imbalanced
+	//If less than 15% of players are infected, set round start as imbalanced
 	bool bImbalanced = (float(iZombies) / float(iSurvivors + iZombies) <= 0.15);
 
 	for (int i = 1; i <= MaxClients; i++)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -629,8 +629,7 @@ public void OnClientDisconnect(int client)
 	DropCarryingItem(client);
 	if (client == g_iZombieTank) g_iZombieTank = 0;
 	
-	if (g_bWaitingForTeamSwitch[client]) 
-		g_bWaitingForTeamSwitch[client] = false;
+	g_bWaitingForTeamSwitch[client] = false;
 	
 	Weapons_ClientDisconnect(client);
 }

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -990,27 +990,27 @@ public Action hook_JoinTeam(int client, const char[] command, int argc)
 		strcopy(cmd1, sizeof(cmd1), "autoteam");
 		
 	else
-		GetCmdArg(1, cmd1, sizeof(cmd1));
-		
-	// Assign team-specific strings
-	if (zomTeam() == INT(TFTeam_Blue))
-	{
-		sSurTeam = "red";
-		sZomTeam = "blue";
-		sZomVgui = "class_blue";
-	}
-	else
-	{
-		sSurTeam = "blue";
-		sZomTeam = "red";
-		sZomVgui = "class_red";
-	}
+		GetCmdArg(1, cmd1, sizeof(cmd1));		
 	
 	if (roundState() >= RoundGrace)
 	{	
 		//Check if client is trying to skip playing as zombie by joining spectator
 		if (StrEqual(cmd1, "spectate", false))
 			CheckZombieBypass(client);
+			
+		// Assign team-specific strings
+		if (zomTeam() == INT(TFTeam_Blue))
+		{
+			sSurTeam = "red";
+			sZomTeam = "blue";
+			sZomVgui = "class_blue";
+		}
+		else
+		{
+			sSurTeam = "blue";
+			sZomTeam = "red";
+			sZomVgui = "class_red";
+		}
 	}
 	
 	if (roundState() > RoundGrace)


### PR DESCRIPTION
This change lets survivors be able to normally move out of spawn without being overwhelmed when either it's the first round or players intentionally switch teams after a round begins, especially in maps that move spawn points after setup ends. No changes were made during the waiting for players, active round and post round periods.

New behaviour:
- Players are still allowed to go into the spectator team as much as they please.


- If a player tries to join the infected team as a survivor during grace period, the gamemode will simply not let them and do nothing besides tell them they aren't allowed to do so in chat.
    - They'll be allowed to switch teams again when it ends, though.


- If a player tries to join any team as a spectator, or when first selecting a team during grace period, they'll stay as spectator and automatically change to infected once setup/grace period ends after being told about it in chat.
   - Only exception is when this player started as infected and for some reason decided to become a spectator, then to join the infected team again.