### PR TITLE
Fix grace period happening during Waiting for Players

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -42,6 +42,7 @@ enum
 enum SZFRoundState
 {
 	SZFRoundState_Setup,
+	SZFRoundState_Waiting,
 	SZFRoundState_Grace,
 	SZFRoundState_Active,
 	SZFRoundState_End,
@@ -1272,7 +1273,11 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	g_iZombieTank = 0;
 	RemoveAllGoo();
 	
-	g_nRoundState = SZFRoundState_Grace;
+	if (g_nRoundState == SZFRoundState_Setup)
+		g_nRoundState = SZFRoundState_Waiting;
+	else
+		g_nRoundState = SZFRoundState_Grace;
+	
 	CPrintToChatAll("{green}Grace period begun. Survivors can change classes.");
 	
 	//Assign players to zombie and survivor teams.
@@ -1410,8 +1415,7 @@ public Action Event_SetupEnd(Event event, const char[] name, bool dontBroadcast)
 void EndGracePeriod()
 {
 	if (!g_bEnabled) return;
-	if (g_nRoundState == SZFRoundState_Active) return;
-	if (g_nRoundState == SZFRoundState_End) return;
+	if (g_nRoundState != SZFRoundState_Grace) return; //No point in ending grace period if it's not grace period it in the first place.
 	
 	g_nRoundState = SZFRoundState_Active;
 	CPrintToChatAll("{orange}Grace period complete. Survivors can no longer change classes.");

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1279,7 +1279,6 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	RemoveAllGoo();
 	
 	g_nRoundState = SZFRoundState_Grace;
-	
 	CPrintToChatAll("{green}Grace period begun. Survivors can change classes.");
 	
 	//Assign players to zombie and survivor teams.

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -42,7 +42,6 @@ enum
 enum SZFRoundState
 {
 	SZFRoundState_Setup,
-	SZFRoundState_Waiting,
 	SZFRoundState_Grace,
 	SZFRoundState_Active,
 	SZFRoundState_End,
@@ -1242,14 +1241,24 @@ public Action Command_MainMenu(int iClient, int iArgs)
 	return Plugin_Handled;
 }
 
+public void TF2_OnWaitingForPlayersStart()
+{
+	if (!g_bEnabled) return;
+	
+	g_nRoundState = SZFRoundState_Setup;
+}
+
+public void TF2_OnWaitingForPlayersEnd()
+{
+	if (!g_bEnabled) return;
+	
+	g_nRoundState = SZFRoundState_Grace;
+}
+
 public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	if (!g_bEnabled) return;
-	if (g_nRoundState == SZFRoundState_Setup)
-	{
-		g_nRoundState = SZFRoundState_Waiting;
-		return;
-	}
+	if (g_nRoundState == SZFRoundState_Setup) return;
 	
 	DetermineControlPoints();
 	
@@ -1279,6 +1288,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	RemoveAllGoo();
 	
 	g_nRoundState = SZFRoundState_Grace;
+	
 	CPrintToChatAll("{green}Grace period begun. Survivors can change classes.");
 	
 	//Assign players to zombie and survivor teams.

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1245,6 +1245,11 @@ public Action Command_MainMenu(int iClient, int iArgs)
 public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	if (!g_bEnabled) return;
+	if (g_nRoundState == SZFRoundState_Setup)
+	{
+		g_nRoundState = SZFRoundState_Waiting;
+		return;
+	}
 	
 	DetermineControlPoints();
 	
@@ -1273,10 +1278,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	g_iZombieTank = 0;
 	RemoveAllGoo();
 	
-	if (g_nRoundState == SZFRoundState_Setup)
-		g_nRoundState = SZFRoundState_Waiting;
-	else
-		g_nRoundState = SZFRoundState_Grace;
+	g_nRoundState = SZFRoundState_Grace;
 	
 	CPrintToChatAll("{green}Grace period begun. Survivors can change classes.");
 	


### PR DESCRIPTION
The plugin restyling (#47) changed a lot of things, but an issue it brought is that with a change to the Round State enum struct, it skips over a step and sees the waiting for players period as an actual round, and this breaks a couple of things:
- The first round skip immunity/mechanic is ignored and will catch players after a set amount of time during waiting for players and will force undeserving players to the infected team in the first round.
- As a result, the anti-exploiting feature introduced with PR #44 will also be active during waiting for players, making everyone (except the very first player) unable to join either team until the emergency 45 sec grace period timer ends, confusing a lot of people.

This PR simply re-adds the waiting for players step as a round state. 