### PR TITLE
Re-do last man minicrit code

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -2482,14 +2482,9 @@ public void OnGameFrame()
 		
 		if (g_nRoundState == SZFRoundState_Active)
 		{
-			if (IsValidClient(iClient) && IsPlayerAlive(iClient) && IsSurvivor(iClient) && iCount == 1)
-			{
-				if (GetActivePlayerCount() >= 6 && !TF2_IsPlayerInCondition(iClient, TFCond_Buffed))
-					TF2_AddCondition(iClient, TFCond_Buffed, TFCondDuration_Infinite);
-				
-				if (GetActivePlayerCount() < 6 && TF2_IsPlayerInCondition(iClient, TFCond_Buffed))
-					TF2_RemoveCondition(iClient, TFCond_Buffed);
-			}
+			//Last man gets minicrit boost if 6 players ingame
+			if (iCount == 1 && IsValidLivingSurvivor(iClient) && GetActivePlayerCount() >= 6)
+				TF2_AddCondition(iClient, TFCond_Buffed, 0.05);
 			
 			//Charger's charge
 			if (IsValidLivingZombie(iClient) && g_nInfected[iClient] == Infected_Charger && TF2_IsPlayerInCondition(iClient, TFCond_Charging))


### PR DESCRIPTION
This really only affects where player is last man with less than 6 living players, attempting to pick up strength powerup does nothing since lastman-minicrit forcefully removed it.

New code simply just give minicrit at very short amount of time on every frame. Not removing minicrit from unexpected places, if less than 6 living players.