### PR TITLE
Update detection into goo touching player

### DIFF
--- a/addons/sourcemod/gamedata/szf.txt
+++ b/addons/sourcemod/gamedata/szf.txt
@@ -29,6 +29,11 @@
 				"linux"		"432"
 				"windows"	"431"
 			}
+			"CTFStunBall::ShouldBallTouch"
+			{
+				"linux"		"262"
+				"windows"	"261"
+			}
 		}
 	}
 }

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -612,7 +612,9 @@ public void OnClientPutInServer(int iClient)
 {
 	CreateTimer(10.0, Timer_InitialHelp, iClient, TIMER_FLAG_NO_MAPCHANGE);
 	
-	DHookEntity(g_hHookGetMaxHealth, false, iClient);
+	if (g_hHookGetMaxHealth)
+		DHookEntity(g_hHookGetMaxHealth, false, iClient);
+	
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_OnPreThinkPost);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	
@@ -4482,7 +4484,8 @@ public void OnEntityCreated(int iEntity, const char[] sClassname)
 	}
 	else if (StrEqual(sClassname, "tf_projectile_stun_ball"))
 	{
-		DHookEntity(g_hHookShouldBallTouch, false, iEntity, _, ShouldBallTouch);
+		if (g_hHookShouldBallTouch)
+			DHookEntity(g_hHookShouldBallTouch, false, iEntity, _, ShouldBallTouch);
 	}
 	else if (StrEqual(sClassname, "tf_dropped_weapon"))
 	{


### PR DESCRIPTION
`SDKHook_StartTouch` and `SDKHook_Touch` on Sandman ball can rarely not call on touching player, and stuns instead of doing usual goo. Use actual sandman's touch functions instead, `CTFStunBall::ShouldBallTouch`.

There also `CTFStunBall::ApplyBallImpactEffectOnVictim` that could be hooked instead, but that does not call when ball is rolling on the round and touching player, unlike `SDKHook_StartTouch` and `SDKHook_Touch`.