### PR TITLE
No more crashes on GiveNamedItem

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -214,7 +214,6 @@ int g_iSmokerBeamHitVictim[TF_MAXPLAYERS];
 float g_flTimeStartAsZombie[TF_MAXPLAYERS];
 bool g_bForceZombieStart[TF_MAXPLAYERS];
 bool g_bClearedInventory[TF_MAXPLAYERS];
-int g_iHookIdGiveNamedItem[TF_MAXPLAYERS] = {-1, ...};
 
 //Map overwrites
 float g_flCapScale = -1.0;
@@ -396,15 +395,7 @@ public void OnPluginEnd()
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
 		if (IsClientInGame(iClient))
-		{
 			EndSound(iClient);
-			
-			if (g_iHookIdGiveNamedItem[iClient] != -1)
-			{
-				DHookRemoveHookID(g_iHookIdGiveNamedItem[iClient]);
-				g_iHookIdGiveNamedItem[iClient] = -1;
-			}
-		}
 	}
 }
 
@@ -626,7 +617,7 @@ public void OnClientPutInServer(int iClient)
 		DHookEntity(g_hHookGetMaxHealth, false, iClient);
 	
 	if (g_hHookGiveNamedItem)
-		g_iHookIdGiveNamedItem[iClient] = DHookEntity(g_hHookGiveNamedItem, false, iClient, DHook_OnGiveNamedItemRemoved, Client_OnGiveNamedItem);
+		DHookEntity(g_hHookGiveNamedItem, false, iClient, _, Client_OnGiveNamedItem);
 	
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_OnPreThinkPost);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
@@ -636,12 +627,6 @@ public void OnClientPutInServer(int iClient)
 
 public void OnClientDisconnect(int iClient)
 {
-	if (g_iHookIdGiveNamedItem[iClient] != -1)
-	{
-		DHookRemoveHookID(g_iHookIdGiveNamedItem[iClient]);
-		g_iHookIdGiveNamedItem[iClient] = -1;
-	}
-	
 	if (!g_bEnabled) return;
 	
 	RequestFrame(CheckZombieBypass, iClient);
@@ -5607,18 +5592,6 @@ public MRESReturn Client_OnGiveNamedItem(int iClient, Handle hReturn, Handle hPa
 	}
 	
 	return MRES_Ignored;
-}
-
-public void DHook_OnGiveNamedItemRemoved(int iHookId)
-{
-	for (int iClient = 1; iClient <= MaxClients; iClient++)
-	{
-		if (g_iHookIdGiveNamedItem[iClient] == iHookId)
-		{
-			g_iHookIdGiveNamedItem[iClient] = -1;
-			return;
-		}
-	}
 }
 
 stock int SDK_GetMaxHealth(int iClient)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -5566,8 +5566,7 @@ public MRESReturn Client_OnGiveNamedItem(int iClient, Handle hReturn, Handle hPa
 	
 	int iIndex = DHookGetParamObjectPtrVar(hParams, 3, 4, ObjectValueType_Int) & 0xFFFF;
 	
-	Handle hTF2ItemsItem; // Pointless but is needed for TF2Items_OnGiveNamedItem
-	Action iAction = TF2Items_OnGiveNamedItem(iClient, sClassname, iIndex, hTF2ItemsItem);
+	Action iAction = OnGiveNamedItem(iClient, sClassname, iIndex);
 	
 	if (iAction == Plugin_Handled)
 	{
@@ -5682,7 +5681,7 @@ stock int GetMorale(int iClient)
 	return g_iMorale[iClient];
 }
 
-public Action TF2Items_OnGiveNamedItem(int iClient, char[] sClassname, int iIndex, Handle& hItem)
+Action OnGiveNamedItem(int iClient, char[] sClassname, int iIndex)
 {
 	int iSlot = TF2_GetItemSlot(iIndex, TF2_GetPlayerClass(iClient));
 	
@@ -5724,4 +5723,9 @@ public Action TF2Items_OnGiveNamedItem(int iClient, char[] sClassname, int iInde
 	}
 	
 	return iAction;
+}
+
+public Action TF2Items_OnGiveNamedItem(int iClient, char[] sClassname, int iIndex, Handle& hItem)
+{
+	return OnGiveNamedItem(iClient, sClassname, iIndex);
 }

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -395,18 +395,6 @@ public void OnPluginStart()
 			OnClientPutInServer(iClient);
 }
 
-public void OnLibraryAdded(const char[] name)
-{
-	if (StrContains(name, "tf2items", false))
-		g_bTF2Items = true;
-}
-
-public void OnLibraryRemoved(const char[] name)
-{
-	if (StrContains(name, "tf2items", false))
-		g_bTF2Items = false;
-}
-
 public void OnPluginEnd()
 {
 	for (int iClient = 1; iClient <= MaxClients; iClient++)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -10,6 +10,8 @@
 #include <tf_econ_data>
 #include <dhooks>
 #include <morecolors>
+
+#undef REQUIRE_EXTENSIONS
 #include <tf2items>
 
 #include "include/superzombiefortress.inc"

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -5514,9 +5514,9 @@ void SDK_Init()
 	else
 		DHookAddParam(g_hHookShouldBallTouch, HookParamType_CBaseEntity);
 	
-	iOffset = hGameData.GetOffset("CTFPlayer::GiveNamedItem");
 	if (!g_bTF2Items)
 	{
+		iOffset = hGameData.GetOffset("CTFPlayer::GiveNamedItem");
 		g_hHookGiveNamedItem = DHookCreate(iOffset, HookType_Entity, ReturnType_CBaseEntity, ThisPointer_CBaseEntity);
 		if (g_hHookGiveNamedItem == null)
 		{

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,3 +15,4 @@ wget "https://raw.githubusercontent.com/FlaminSarge/tf2attributes/master/tf2attr
 wget "https://raw.githubusercontent.com/nosoop/SM-TFEconData/master/scripting/include/tf_econ_data.inc" -O include/tf_econ_data.inc
 wget "https://bitbucket.org/Drifter321/dhooks2/raw/009f11c6c518227c51d708af69f4c759147f704b/sourcemod/scripting/include/dhooks.inc" -O include/dhooks.inc
 wget "https://www.doctormckay.com/download/scripting/include/morecolors.inc" -O include/morecolors.inc
+wget "https://raw.githubusercontent.com/asherkin/TF2Items/master/pawn/tf2items.inc" -O include/tf2items.inc


### PR DESCRIPTION
Apparently hooking `GiveNamedItem` while TF2Items' hook is active causes crashes so we do a new thing now:
* If TF2Items is loaded we use the `TF2Items_OnGiveNamedItem` forward
* Otherwise we hook `GiveNamedItem` ourselves through dhooks