### PR TITLE
(Slight) rework for damage detection for Tank selection

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -137,7 +137,7 @@ ArrayList g_aFastRespawn;
 
 bool g_bBackstabbed[TF_MAXPLAYERS];
 
-int g_iDamageInfected[TF_MAXPLAYERS];
+int g_iDamageZombie[TF_MAXPLAYERS];
 int g_iDamageTakenLife[TF_MAXPLAYERS];
 int g_iDamageDealtLife[TF_MAXPLAYERS];
 
@@ -661,7 +661,7 @@ public void OnClientPutInServer(int iClient)
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_OnPreThinkPost);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	
-	g_iDamageInfected[iClient] = 0;
+	g_iDamageZombie[iClient] = 0;
 }
 
 public void OnClientDisconnect(int iClient)
@@ -1322,7 +1322,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		g_iDamageInfected[iClient] = 0;
+		g_iDamageZombie[iClient] = 0;
 		g_iKillsThisLife[iClient] = 0;
 		g_bSpawnAsSpecialInfected[iClient] = false;
 		g_nInfected[iClient] = Infected_None;
@@ -1899,7 +1899,7 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	
 	if (g_nInfected[iVictim] == Infected_Tank)
 	{
-		g_iDamageInfected[iVictim] = 0;
+		g_iDamageZombie[iVictim] = 0;
 		
 		int iWinner = 0;
 		float flHighest = 0.0;
@@ -2139,7 +2139,7 @@ public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcas
 		g_iDamageDealtLife[iAttacker] += iDamageAmount;
 		
 		if (IsValidZombie(iAttacker))
-			g_iDamageInfected[iAttacker] += iDamageAmount;
+			g_iDamageZombie[iAttacker] += iDamageAmount;
 	}
 	
 	return Plugin_Continue;
@@ -4689,10 +4689,10 @@ int GetMostDamageZom()
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 		if (IsValidZombie(iClient))
-			if (g_iDamageInfected[iClient] > iHighest) iHighest = g_iDamageInfected[iClient];
+			if (g_iDamageZombie[iClient] > iHighest) iHighest = g_iDamageZombie[iClient];
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
-		if (IsValidZombie(iClient) && g_iDamageInfected[iClient] >= iHighest)
+		if (IsValidZombie(iClient) && g_iDamageZombie[iClient] >= iHighest)
 			aClients.Push(iClient);
 	
 	if (aClients.Length <= 0)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -137,7 +137,7 @@ ArrayList g_aFastRespawn;
 
 bool g_bBackstabbed[TF_MAXPLAYERS];
 
-int g_iDamage[TF_MAXPLAYERS];
+int g_iDamageInfected[TF_MAXPLAYERS];
 int g_iDamageTakenLife[TF_MAXPLAYERS];
 int g_iDamageDealtLife[TF_MAXPLAYERS];
 
@@ -661,7 +661,7 @@ public void OnClientPutInServer(int iClient)
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_OnPreThinkPost);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	
-	g_iDamage[iClient] = GetAverageDamage();
+	g_iDamageInfected[iClient] = 0;
 }
 
 public void OnClientDisconnect(int iClient)
@@ -1322,7 +1322,7 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 	{
-		g_iDamage[iClient] = 0;
+		g_iDamageInfected[iClient] = 0;
 		g_iKillsThisLife[iClient] = 0;
 		g_bSpawnAsSpecialInfected[iClient] = false;
 		g_nInfected[iClient] = Infected_None;
@@ -1899,7 +1899,7 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	
 	if (g_nInfected[iVictim] == Infected_Tank)
 	{
-		g_iDamage[iVictim] = GetAverageDamage();
+		g_iDamageInfected[iVictim] = 0;
 		
 		int iWinner = 0;
 		float flHighest = 0.0;
@@ -2137,7 +2137,9 @@ public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcas
 	{
 		g_iDamageTakenLife[iVictim] += iDamageAmount;
 		g_iDamageDealtLife[iAttacker] += iDamageAmount;
-		g_iDamage[iAttacker] += iDamageAmount;
+		
+		if (IsValidZombie(iAttacker))
+			g_iDamageInfected[iAttacker] += iDamageAmount;
 	}
 	
 	return Plugin_Continue;
@@ -4687,10 +4689,10 @@ int GetMostDamageZom()
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 		if (IsValidZombie(iClient))
-			if (g_iDamage[iClient] > iHighest) iHighest = g_iDamage[iClient];
+			if (g_iDamageInfected[iClient] > iHighest) iHighest = g_iDamageInfected[iClient];
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
-		if (IsValidZombie(iClient) && g_iDamage[iClient] >= iHighest)
+		if (IsValidZombie(iClient) && g_iDamageInfected[iClient] >= iHighest)
 			aClients.Push(iClient);
 	
 	if (aClients.Length <= 0)
@@ -4788,22 +4790,6 @@ stock bool RemoveSecondaryWearable(int iClient)
 	}
 	
 	return false;
-}
-
-int GetAverageDamage()
-{
-	int iTotalDamage = 0;
-	int iCount = 0;
-	for (int i = 1; i <= MaxClients; i++)
-	{
-		if (IsClientInGame(i))
-		{
-			iTotalDamage += g_iDamage[i];
-			iCount++;
-		}
-	}
-	
-	return RoundFloat(float(iTotalDamage) / float(iCount));
 }
 
 int GetActivePlayerCount()

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -4688,8 +4688,8 @@ int GetMostDamageZom()
 	int iHighest = 0;
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
-		if (IsValidZombie(iClient))
-			if (g_iDamageZombie[iClient] > iHighest) iHighest = g_iDamageZombie[iClient];
+		if (IsValidZombie(iClient) && g_iDamageZombie[iClient] > iHighest)
+			iHighest = g_iDamageZombie[iClient];
 	
 	for (int iClient = 1; iClient <= MaxClients; iClient++)
 		if (IsValidZombie(iClient) && g_iDamageZombie[iClient] >= iHighest)


### PR DESCRIPTION
Player selection for Tank spawns has always worked as intended - it chooses the player who has dealt the most damage for that round - but the way it sees how much damage a player has dealt can be questionable at times.

How it works now: Everyone (obviously) starts at 0 damage and all damage dealt is added towards a damage counter, even damage done as a survivor. Players who joined the server mid-round have their damage counter set to the average damage dealt by all players, **including survivors**. When a Tank dies, that player's damage counter is also set to the average damage dealt by all players.

This means that players who died or (especially) joined the server mid-round have a much greater chance to become a Tank, as damage done by survivors greatly exceed damage done by infected. It's also common to see a player become a Tank multiple times in a row because of this.

This PR does a couple of changes:
- Removed the 'average damage' function altogether, setting damage counters to 0 in these cases instead.
- Made Tank selection only consider infected performance.

This does add a little incentive for players who start as infected to deal damage as they get a head start for Tank consideration, and the more incentive to get starting infected to actually play the game, the better.