### PR TITLE
Prevent unneeded respawns during round start

### DIFF
--- a/addons/sourcemod/gamedata/szf.txt
+++ b/addons/sourcemod/gamedata/szf.txt
@@ -19,6 +19,16 @@
 		}
 		"Offsets"
 		{
+			"CTeamplayRoundBasedRules::SetWinningTeam"
+			{
+				"linux"		"161"
+				"windows"	"160"
+			}
+			"CTeamplayRoundBasedRules::RoundRespawn"
+			{
+				"linux"		"226"
+				"windows"	"224"
+			}
 			"CBasePlayer::EquipWearable"
 			{
 				"linux"		"431"

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -529,7 +529,7 @@ stock void TF2_RemoveAmmo(int iClient, int iSlot, int iAmmo)
 //
 ////////////////////////////////////////////////////////////
 
-stock void SpawnClient(int iClient, TFTeam nTeam)
+stock void SpawnClient(int iClient, TFTeam nTeam, bool bRespawn = true)
 {
 	//1. Prevent players from spawning if they're on an invalid team.
 	//        Prevent players from spawning as an invalid class.
@@ -545,12 +545,13 @@ stock void SpawnClient(int iClient, TFTeam nTeam)
 		//Use of m_lifeState here prevents:
 		//1. "[Player] Suicided" messages.
 		//2. Adding a death to player stats.
-		TF2_RemoveAllWeapons(iClient);
 		SetEntProp(iClient, Prop_Send, "m_lifeState", 2);
-		TF2_SetPlayerClass(iClient, nClass, false, true);
+		TF2_SetPlayerClass(iClient, nClass);
 		TF2_ChangeClientTeam(iClient, nTeam);
 		SetEntProp(iClient, Prop_Send, "m_lifeState", 0);
-		TF2_RespawnPlayer(iClient);
+		
+		if (bRespawn)
+			TF2_RespawnPlayer(iClient);
 	}
 }
 


### PR DESCRIPTION
Fix #53 

`CTeamplayRoundBasedRules::RoundRespawn` function is used for respawning everyone,  called right before `teamplay_round_start` event, but also switch and scramble teams. This PR hooks `CTeamplayRoundBasedRules::RoundRespawn` so round start stuffs can be done before client respawns, so client class and team can be prepared for `CTeamplayRoundBasedRules::RoundRespawn` respawning everyone, rather than force respawn everyone, costing more ents during round start.

However we need to be careful with switch and scramble teams inside `CTeamplayRoundBasedRules::RoundRespawn` as that can cause players to spawn in wrong team. team switch is prevented by `CTeamplayRoundBasedRules::SetWinningTeam` param `bSwitchTeams`, and scramble teams by convar `mp_scrambleteams_auto`.

This whole change should save about 150-200 entities in full server, allowing map makers use more entity space without crashing the server.