### PR TITLE
Disable red's func_respawnroom after grace period ends

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1553,8 +1553,8 @@ void EndGracePeriod()
 	int iEntity = -1;
 	while ((iEntity = FindEntityByClassname(iEntity, "func_respawnroom")) != -1)
 	{
-		if (view_as<TFTeam>(GetEntProp(iEntity, Prop_Data, "m_iTeamNum")) == TFTeam_Survivor)
-			AcceptEntityInput(iEntity, "Disable");
+		if (view_as<TFTeam>(GetEntProp(iEntity, Prop_Send, "m_iTeamNum")) == TFTeam_Survivor)
+			RemoveEntity(iEntity);
 	}
 	
 	int iSurvivors = GetSurvivorCount();

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1549,6 +1549,14 @@ void EndGracePeriod()
 	g_nRoundState = SZFRoundState_Active;
 	CPrintToChatAll("{orange}Grace period complete. Survivors can no longer change classes.");
 	
+	//Disable func_respawnroom so clients dont accidentally respawn and join zombie
+	int iEntity = -1;
+	while ((iEntity = FindEntityByClassname(iEntity, "func_respawnroomvisualizer")) != -1)
+	{
+		if (view_as<TFTeam>(GetEntProp(iEntity, Prop_Data, "m_iTeamNum")) == TFTeam_Survivor)
+			AcceptEntityInput(iEntity, "Disable");
+	}
+	
 	int iSurvivors = GetSurvivorCount();
 	int iZombies = GetZombieCount();
 	

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1551,7 +1551,7 @@ void EndGracePeriod()
 	
 	//Disable func_respawnroom so clients dont accidentally respawn and join zombie
 	int iEntity = -1;
-	while ((iEntity = FindEntityByClassname(iEntity, "func_respawnroomvisualizer")) != -1)
+	while ((iEntity = FindEntityByClassname(iEntity, "func_respawnroom")) != -1)
 	{
 		if (view_as<TFTeam>(GetEntProp(iEntity, Prop_Data, "m_iTeamNum")) == TFTeam_Survivor)
 			AcceptEntityInput(iEntity, "Disable");


### PR DESCRIPTION
When grace period ends and red tried to change loadout or its class, they would get force respawned and moved to zombie team. Disable func_respawnroom to prevent client accidentally respawn.

Reported at https://github.com/DFS-Servers/BugReportsAndSuggestions/issues/246