### PR TITLE
make the candy cane hurt more but not a lot

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -642,6 +642,11 @@
 		{
 			"attrib"	"69 ; 0.4" //health from healers penalty
 		}
+		"317"	//The Candy Cane
+		{
+			"text"		"{orange}The Candy Cane {red}makes you take 10%% additional damage."
+			"attrib"	"412 ; 1.1 ; 65 ; 1.0"
+		}
 		"154"	//Pain Train
 		{
 			"text"		"{orange}The Pain Train {red}makes you take 10%% additional damage."


### PR DESCRIPTION
there's a 25% additional explosion damage att on this weapon, however since zombies don't have that and 25% is a lot of damage for scunt i converted it down to 10% additional general damage

i also nulled out explosion damage because additional explosion damage on turtle attack/pen15/etc. lol