### PR TITLE
Replace hardcoded tank and weapon pickup voice lines

### DIFF
--- a/addons/sourcemod/scripting/szf/event.sp
+++ b/addons/sourcemod/scripting/szf/event.sp
@@ -227,6 +227,9 @@ public Action Event_PlayerSpawn(Event event, const char[] name, bool dontBroadca
 						SetCookie(i, 2, g_cFirstTimeSurvivor);
 					}
 					
+					SetVariantString("MP_CONCEPT_MVM_TANK_CALLOUT");
+					AcceptEntityInput(i, "SpeakResponseConcept");
+					
 					CPrintToChat(i, "{red}Incoming TAAAAANK!");
 					
 					if (GetCurrentSound(i) != SoundMusic_LastStand || !IsMusicOverrideOn()) //lms current sound check seems not to work, may need to check it later
@@ -336,6 +339,12 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		
 		int iWinner = 0;
 		float flHighest = 0.0;
+		
+		for (int i = 0; i < sizeof(iKillers); i++)
+		{
+			SetVariantString("MP_CONCEPT_MVM_TANK_DEAD");
+			AcceptEntityInput(iKillers[i], "SpeakResponseConcept");
+		}
 		
 		EmitSoundToAll(g_sVoZombieTankDeath[GetRandomInt(0, sizeof(g_sVoZombieTankDeath)-1)]);
 		

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -266,25 +266,16 @@ void PickupWeapon(int iClient, Weapon wep, int iTarget)
 	g_bCanPickup[iClient] = false;
 	CreateTimer(PICKUP_COOLDOWN, Timer_ResetPickup, iClient);
 	
-	//Weapon pickup quote
-	char sSound[PLATFORM_MAX_PATH];
-	TFClassType iClass = TF2_GetPlayerClass(iClient);
-	
-	switch (iClass)
+	switch (wep.nRarity)
 	{
-		case TFClass_Scout: Format(sSound, sizeof(sSound), g_sVoWeaponScout[GetRandomInt(0, sizeof(g_sVoWeaponScout)-1)]);
-		case TFClass_Soldier: Format(sSound, sizeof(sSound), g_sVoWeaponSoldier[GetRandomInt(0, sizeof(g_sVoWeaponSoldier)-1)]);
-		case TFClass_Pyro: Format(sSound, sizeof(sSound), g_sVoWeaponPyro[GetRandomInt(0, sizeof(g_sVoWeaponPyro)-1)]);
-		case TFClass_DemoMan: Format(sSound, sizeof(sSound), g_sVoWeaponDemoman[GetRandomInt(0, sizeof(g_sVoWeaponDemoman)-1)]);
-		case TFClass_Heavy: Format(sSound, sizeof(sSound), g_sVoWeaponHeavy[GetRandomInt(0, sizeof(g_sVoWeaponHeavy)-1)]);
-		case TFClass_Engineer: Format(sSound, sizeof(sSound), g_sVoWeaponEngineer[GetRandomInt(0, sizeof(g_sVoWeaponEngineer)-1)]);
-		case TFClass_Medic: Format(sSound, sizeof(sSound), g_sVoWeaponMedic[GetRandomInt(0, sizeof(g_sVoWeaponMedic)-1)]);
-		case TFClass_Sniper: Format(sSound, sizeof(sSound), g_sVoWeaponSniper[GetRandomInt(0, sizeof(g_sVoWeaponSniper)-1)]);
-		case TFClass_Spy: Format(sSound, sizeof(sSound), g_sVoWeaponSpy[GetRandomInt(0, sizeof(g_sVoWeaponSpy)-1)]);
+		case WeaponRarity_Common: SetVariantString("MP_CONCEPT_MVM_LOOT_COMMON");
+		case WeaponRarity_Uncommon: SetVariantString("MP_CONCEPT_MVM_LOOT_RARE");
+		case WeaponRarity_Rare: SetVariantString("MP_CONCEPT_MVM_LOOT_ULTRARARE");
 	}
 	
-	EmitSoundToAll(sSound, iClient, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+	AcceptEntityInput(iClient, "SpeakResponseConcept");
 	
+	TFClassType iClass = TF2_GetPlayerClass(iClient);
 	int iSlot = TF2_GetItemSlot(wep.iIndex, iClass);
 	WeaponType iWepType = GetWeaponType(iTarget);
 	

--- a/addons/sourcemod/scripting/szf/sdkhook.sp
+++ b/addons/sourcemod/scripting/szf/sdkhook.sp
@@ -306,17 +306,8 @@ public Action Client_OnTakeDamage(int iVictim, int &iAttacker, int &iInflicter, 
 					//"SHOOT THAT TANK" voice call
 					if (g_flDamageDealtAgainstTank[iAttacker] == 0)
 					{
-						char sPath[PLATFORM_MAX_PATH];
-						switch (TF2_GetPlayerClass(iAttacker))
-						{
-							case TFClass_Soldier: Format(sPath, sizeof(sPath), g_sVoTankSoldier[GetRandomInt(0, sizeof(g_sVoTankSoldier)-1)]);
-							case TFClass_Heavy: Format(sPath, sizeof(sPath), g_sVoTankHeavy[GetRandomInt(0, sizeof(g_sVoTankHeavy)-1)]);
-							case TFClass_Engineer: Format(sPath, sizeof(sPath), g_sVoTankEngineer[GetRandomInt(0, sizeof(g_sVoTankEngineer)-1)]);
-							case TFClass_Medic: Format(sPath, sizeof(sPath), g_sVoTankMedic[GetRandomInt(0, sizeof(g_sVoTankMedic)-1)]);
-						}
-						
-						if (sPath[0] != '\0')
-							EmitSoundToAll(sPath, iAttacker, SNDCHAN_VOICE, SNDLEVEL_SCREAMING);
+						SetVariantString("MP_CONCEPT_MVM_ATTACK_THE_TANK");
+						AcceptEntityInput(iAttacker, "SpeakResponseConcept");
 					}
 					
 					//Don't instantly kill the tank on a backstab

--- a/addons/sourcemod/scripting/szf/sound.sp
+++ b/addons/sourcemod/scripting/szf/sound.sp
@@ -216,14 +216,6 @@ char g_sVoCarryScout[][PLATFORM_MAX_PATH] =
 	"scout_go02.mp3"
 };
 
-char g_sVoWeaponScout[][PLATFORM_MAX_PATH] =
-{
-	"scout_mvm_loot_common03.mp3",
-	"scout_mvm_loot_common04.mp3",
-	"scout_mvm_loot_rare01.mp3",
-	"scout_mvm_loot_rare02.mp3"
-};
-
 
 /* Soldier */
 char g_sVoCarrySoldier[][PLATFORM_MAX_PATH] =
@@ -245,23 +237,6 @@ char g_sVoCarrySoldier[][PLATFORM_MAX_PATH] =
 	"vo/soldier_battlecry06.mp3"
 };
 
-char g_sVoWeaponSoldier[][PLATFORM_MAX_PATH] =
-{
-	"vo/soldier_mvm_loot_common01.mp3",
-	"vo/soldier_mvm_loot_common02.mp3",
-	"vo/soldier_mvm_loot_common03.mp3",
-	"vo/soldier_mvm_loot_rare01.mp3",
-	"vo/soldier_mvm_loot_rare02.mp3",
-	"vo/soldier_mvm_loot_rare03.mp3",
-	"vo/soldier_mvm_loot_rare04.mp3"
-};
-
-char g_sVoTankSoldier[][PLATFORM_MAX_PATH] =
-{
-	"vo/soldier_mvm_tank_shooting01.mp3",
-	"vo/soldier_mvm_tank_shooting02.mp3"
-};
-
 
 /* Pyro */
 char g_sVoCarryPyro[][PLATFORM_MAX_PATH] =
@@ -275,15 +250,8 @@ char g_sVoCarryPyro[][PLATFORM_MAX_PATH] =
 	"vo/pyro_moveup01.mp3"
 };
 
-char g_sVoWeaponPyro[][PLATFORM_MAX_PATH] =
-{
-	"vo/pyro_battlecry01.mp3",
-	"vo/pyro_battlecry02.mp3",
-	"vo/pyro_positivevocalization01.mp3"
-};
 
-
-/* Demoman -- does not have tank lines */
+/* Demoman */
 char g_sVoCarryDemoman[][PLATFORM_MAX_PATH] =
 {
 	"vo/demoman_go01.mp3",
@@ -302,17 +270,6 @@ char g_sVoCarryDemoman[][PLATFORM_MAX_PATH] =
 	"vo/demoman_gibberish13.mp3"
 };
 
-char g_sVoWeaponDemoman[][PLATFORM_MAX_PATH] =
-{
-	"vo/demoman_mvm_loot_common01.mp3",
-	"vo/demoman_mvm_loot_common02.mp3",
-	"vo/demoman_mvm_loot_common03.mp3",
-	"vo/demoman_mvm_loot_common04.mp3",
-	"vo/demoman_mvm_loot_godlike01.mp3",
-	"vo/demoman_mvm_loot_rare01.mp3",
-	"vo/demoman_mvm_loot_rare02.mp3"
-};
-
 
 /* Heavy */
 char g_sVoCarryHeavy[][PLATFORM_MAX_PATH] =
@@ -320,23 +277,6 @@ char g_sVoCarryHeavy[][PLATFORM_MAX_PATH] =
 	"heavy_autocappedintelligence01.mp3",
 	"heavy_go02.mp3",
 	"heavy_go03.mp3"
-};
-
-char g_sVoWeaponHeavy[][PLATFORM_MAX_PATH] =
-{
-	"heavy_mvm_get_upgrade04.mp3",
-	"heavy_mvm_loot_common01.mp3",
-	"heavy_mvm_loot_common02.mp3",
-	"heavy_mvm_loot_godlike02.mp3",
-	"heavy_specialweapon05.mp3",
-	"heavy_specialweapon09.mp3"
-};
-
-char g_sVoTankHeavy[][PLATFORM_MAX_PATH] =
-{
-	"heavy_mvm_tank_alert01.mp3",
-	"heavy_mvm_tank_alert02.mp3",
-	"heavy_mvm_tank_alert03.mp3"
 };
 
 /* Engineer */
@@ -351,25 +291,6 @@ char g_sVoCarryEngineer[][PLATFORM_MAX_PATH] =
 	"vo/engineer_laughevil01.mp3",
 	"vo/engineer_laughevil04.mp3",
 	"vo/engineer_laughevil06.mp3"
-};
-
-char g_sVoWeaponEngineer[][PLATFORM_MAX_PATH] =
-{
-	"vo/engineer_mvm_loot_common01.mp3",
-	"vo/engineer_mvm_loot_common02.mp3",
-	"vo/engineer_mvm_loot_godlike01.mp3",
-	"vo/engineer_mvm_loot_godlike02.mp3",
-	"vo/engineer_mvm_loot_godlike03.mp3",
-	"vo/engineer_mvm_loot_rare01.mp3",
-	"vo/engineer_mvm_loot_rare02.mp3",
-	"vo/engineer_mvm_loot_rare03.mp3",
-	"vo/engineer_mvm_loot_rare04.mp3"
-};
-
-char g_sVoTankEngineer[][PLATFORM_MAX_PATH] =
-{
-	"vo/engineer_mvm_tank_shooting01.mp3",
-	"vo/engineer_meleedare01.mp3"
 };
 
 
@@ -387,27 +308,8 @@ char g_sVoCarryMedic[][PLATFORM_MAX_PATH] =
 	"vo/medic_yes03.mp3"
 };
 
-char g_sVoWeaponMedic[][PLATFORM_MAX_PATH] =
-{
-	"vo/medic_mvm_loot_common01.mp3",
-	"vo/medic_mvm_loot_common02.mp3",
-	"vo/medic_mvm_loot_common03.mp3",
-	"vo/medic_mvm_loot_rare02.mp3",
-	"vo/medic_mvm_loot_godlike01.mp3",
-	"vo/medic_mvm_loot_godlike02.mp3",
-	"vo/medic_mvm_loot_godlike03.mp3",
-	"vo/medic_specialcompleted02.mp3",
-	"vo/medic_specialcompleted03.mp3"
-};
 
-char g_sVoTankMedic[][PLATFORM_MAX_PATH] =
-{
-	"vo/medic_mvm_tank_shooting01.mp3",
-	"vo/medic_mvm_tank_shooting02.mp3"
-};
-
-
-/* Sniper -- does not have tank lines */
+/* Sniper */
 char g_sVoCarrySniper[][PLATFORM_MAX_PATH] =
 {
 	"vo/sniper_autocappedcontrolpoint01.mp3",
@@ -436,19 +338,6 @@ char g_sVoCarrySniper[][PLATFORM_MAX_PATH] =
 	"vo/sniper_specialweapon09.mp3"
 };
 
-char g_sVoWeaponSniper[][PLATFORM_MAX_PATH] =
-{
-	"vo/sniper_specialweapon01.mp3",
-	"vo/sniper_specialweapon02.mp3",
-	"vo/sniper_specialweapon03.mp3",
-	"vo/sniper_specialweapon04.mp3",
-	"vo/sniper_specialweapon05.mp3",
-	"vo/sniper_specialweapon06.mp3",
-	"vo/sniper_specialweapon07.mp3",
-	"vo/sniper_specialweapon08.mp3",
-	"vo/sniper_specialweapon09.mp3"
-};
-
 
 /* Spy */
 char g_sVoCarrySpy[][PLATFORM_MAX_PATH] =
@@ -458,10 +347,6 @@ char g_sVoCarrySpy[][PLATFORM_MAX_PATH] =
 	"spy_go02.mp3"
 };
 
-char g_sVoWeaponSpy[][PLATFORM_MAX_PATH] =
-{
-	"spy_mvm_loot_common01.mp3"
-};
 
 /* Common Infected */
 char g_sVoZombieCommonDefault[][PLATFORM_MAX_PATH] =
@@ -678,25 +563,16 @@ void SoundPrecache()
 	//---//
 	
 	for (int i = 0; i < sizeof(g_sVoCarrySoldier); i++) PrecacheSound(g_sVoCarrySoldier[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponSoldier); i++) PrecacheSound(g_sVoWeaponSoldier[i]);
-	for (int i = 0; i < sizeof(g_sVoTankSoldier); i++) PrecacheSound(g_sVoTankSoldier[i]);
 	
 	for (int i = 0; i < sizeof(g_sVoCarryPyro); i++) PrecacheSound(g_sVoCarryPyro[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponPyro); i++) PrecacheSound(g_sVoWeaponPyro[i]);
 	
 	for (int i = 0; i < sizeof(g_sVoCarryDemoman); i++) PrecacheSound(g_sVoCarryDemoman[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponDemoman); i++) PrecacheSound(g_sVoCarryDemoman[i]);
 	
 	for (int i = 0; i < sizeof(g_sVoCarryEngineer); i++) PrecacheSound(g_sVoCarryEngineer[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponEngineer); i++) PrecacheSound(g_sVoWeaponEngineer[i]);
-	for (int i = 0; i < sizeof(g_sVoTankEngineer); i++) PrecacheSound(g_sVoTankEngineer[i]);
 	
 	for (int i = 0; i < sizeof(g_sVoCarryMedic); i++) PrecacheSound(g_sVoCarryMedic[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponMedic); i++) PrecacheSound(g_sVoWeaponMedic[i]);
-	for (int i = 0; i < sizeof(g_sVoTankMedic); i++) PrecacheSound(g_sVoTankMedic[i]);
 	
 	for (int i = 0; i < sizeof(g_sVoCarrySniper); i++) PrecacheSound(g_sVoCarrySniper[i]);
-	for (int i = 0; i < sizeof(g_sVoWeaponSniper); i++) PrecacheSound(g_sVoWeaponSniper[i]);
 	
 	//---//
 	


### PR DESCRIPTION
- Uses ``SpeakResponseConcept`` with existing MvM response concepts instead of grabbing a random sound from a hardcoded array
- Adds voice lines for when a tank spawns
- Utilizes different weapon pickup lines for different weapon rarities

Didn't test this, but it should work and fit quite nicely