### PR TITLE
Broken crash fix

### DIFF
--- a/addons/sourcemod/gamedata/szf.txt
+++ b/addons/sourcemod/gamedata/szf.txt
@@ -70,7 +70,7 @@
 				{
 					"pActivator"
 					{
-						"type"	"cbaseentity"
+						"type"	"int"
 					}
 				}
 			}

--- a/addons/sourcemod/scripting/szf/dhook.sp
+++ b/addons/sourcemod/scripting/szf/dhook.sp
@@ -6,7 +6,7 @@ static int g_iHookIdGiveNamedItem[TF_MAXPLAYERS];
 
 void DHook_Init(GameData hSZF)
 {
-	DHook_CreateDetour(hSZF, "CGameUI::Deactivate", DHook_CGameUI_Deactivate_Pre);
+	DHook_CreateDetour(hSZF, "CGameUI::Deactivate", DHook_DeactivatePre, _);
 	
 	g_hDHookSetWinningTeam = DHook_CreateVirtual(hSZF, "CTeamplayRoundBasedRules::SetWinningTeam");
 	g_hDHookRoundRespawn = DHook_CreateVirtual(hSZF, "CTeamplayRoundBasedRules::RoundRespawn");
@@ -73,15 +73,10 @@ void DHook_HookGamerules()
 	DHookGamerules(g_hDHookRoundRespawn, false, _, DHook_RoundRespawnPre);
 }
 
-public MRESReturn DHook_CGameUI_Deactivate_Pre(int iThis, Handle hParams)
+public MRESReturn DHook_DeactivatePre(int iThis, Handle hParams)
 {
 	if (!g_bEnabled)
 		return MRES_Ignored;
-	
-	int iClient = GetEntPropEnt(iThis, Prop_Data, "m_player");
-	// Don't allow zombies drop ammo and dropped weapon
-	if (0 < iClient <= MaxClients && IsZombie(iClient))
-		return MRES_Supercede;
 	
 	// Detour used to prevent a crash with "game_ui" entity
 	// World entity 0 should always be valid


### PR DESCRIPTION
- Commit redsunservers/SuperZombieFortress@6bf3a616d0b9276cf5b217d6ee4c3c9cc276b06f has broken the crash fix I had submitted https://github.com/redsunservers/SuperZombieFortress/pull/65

Moreover the move to dhook over a config file was unproperly done the argument was set as `entity` instead of `int` like it should have been, as mentioned in the PR above. I.e to pass a raw pointer.

This misport has probably prompted the commit mentioned as well.

Finally commit redsunservers/SuperZombieFortress@3073035178496d82f899d712f5d85b7db67ba348 introduced another mishap.
Considering `game_ui` as a player/client. This error has also been corrected, fetching properly the client from the entity's datamap. (Not sure what this plugin function is even attempting)

Note: those changes haven't been tested, but should work