### PR TITLE
Atomizer and Eureka Effect reworks

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -661,7 +661,7 @@
 		"589"	//Eureka Effect
 		{
 			"text"		"Melee_EurekaEffect"
-			"attrib"	"113 ; 6.25 ; 352 ; 0.0"
+			"attrib"	"113 ; 12.5 ; 352 ; 0.0"
 		}
 		"37"	//Ubersaw
 		{

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -623,6 +623,11 @@
 	
 	"melee"
 	{
+		"450"	//Atomizer
+		{
+			"text"		"Melee_Atomizer"
+			"attrib"	"250 ; 0.0 ; 215 ; 215.0"
+		}
 		"317"	//The Candy Cane
 		{
 			"text"		"Melee_CandyCane"
@@ -656,7 +661,7 @@
 		"589"	//Eureka Effect
 		{
 			"text"		"Melee_EurekaEffect"
-			"attrib"	"286 ; 1.333 ; 352 ; 0.0"
+			"attrib"	"113 ; 6.25 ; 352 ; 0.0"
 		}
 		"37"	//Ubersaw
 		{

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -36,24 +36,6 @@
 		"en"		"{1}Zombies are resting..."
 	}
 	
-	"Tank_AlreadyHaveOne"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1}Zombies already have a tank."
-	}
-	
-	"Tank_AlreadyOnWay"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1}A zombie tank is already on the way."
-	}
-	
-	"Tank_FrenzyOn"
-	{
-		"#format"	"{1:s}"
-		"en"		"{1}Zombies are frenzied, tanks cannot spawn during frenzy."
-	}
-	
 	"Tank_Chosen"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -74,8 +56,14 @@
 	
 	"Tank_Died"
 	{
-		"#format"	"{1:N}{2:N}{3:d}"
+		"#format"	"{1:N},{2:N},{3:d}"
 		"en"		"The Tank '{1}' has died\nMost damage: {2} ({3})"
+	}
+	
+	"Tank_Multi_Died"
+	{
+		"#format"	"{1:d},{2:N},{3:d}"
+		"en"		"{1} tanks has died\nMost damage: {2} ({3})"
 	}
 	
 	"Carry_Pickup"
@@ -97,7 +85,7 @@
 	
 	"Survivor_Last"
 	{
-		"#format"	"{1:s}{2:s}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"{1}{2} is the last survivor!"
 	}
 	
@@ -512,9 +500,14 @@
 		"en"		"Infected gain bonuses when sticking together as a hoarde and can enrage which boost health or activate special abilities as special infected.\nEnrage is used by calling for a 'medic' and has a cooldown after use.\nYou may be given the option to respawn as a special infected using 'medic'."
 	}
 	
+	"Menu_ClassesSurvivorsScout"
+	{
+		"en"		"Has 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
+	}
+	
 	"Menu_ClassesSurvivorsSoldier"
 	{
-		"en"		"Gains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
+		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
 	}
 	
 	"Menu_ClassesSurvivorsPyro"
@@ -524,7 +517,7 @@
 	
 	"Menu_ClassesSurvivorsDemoman"
 	{
-		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
+		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
 	}
 	
 	"Menu_ClassesSurvivorsHeavy"
@@ -539,47 +532,47 @@
 	
 	"Menu_ClassesSurvivorsMedic"
 	{
-		"en"		"Medigun has a 60%% heal rate penalty."
+		"en"		"Medigun has a heal rate penalty."
 	}
 	
 	"Menu_ClassesSurvivorsSniper"
 	{
-		"en"		"SMG doesn't have to reload.\nJarate slows down Infected.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
+		"en"		"SMG doesn't have to reload.\nJarate slows down Infected.\nHas 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
 	}
 	
 	"Menu_ClassesSurvivorsSpy"
 	{
-		"en"		"Starts with cloak watches and disguise kit.\nGains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
+		"en"		"Starts with cloak watches and disguise kit.\nHas 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
 	}
 	
 	"Menu_ClassesInfectedScout"
 	{
-		"en"		"Has Sandman to slow down survivors\nAble to keep drinks in secondary slot to use"
+		"en"		"Has Sandman to slow down survivors.\nAble to keep drinks in secondary slot to use."
 	}
 	
 	"Menu_ClassesInfectedSoldier"
 	{
-		"en"		"Suffers less knockback from attackers.\nBenefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep banners in secondary slot to use"
+		"en"		"Benefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep banners in secondary slot to use."
 	}
 	
 	"Menu_ClassesInfectedPyro"
 	{
-		"en"		"Has Sharpened Volcano Fragment to ignite survivors.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
+		"en"		"Has Sharpened Volcano Fragment to ignite survivors.\nAfterburn damage is reduced.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
 	}
 	
 	"Menu_ClassesInfectedDemoman"
 	{
-		"en"		"Has Eyelander to damage survivors with long range\n.Benefits less from movement speed and health regeneration bonuses while in a horde."
+		"en"		"Has Eyelander to damage survivors with long range.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
 	}
 	
 	"Menu_ClassesInfectedHeavy"
 	{
-		"en"		"Blocks fatal attacks, reducing damage to 150.\nSuffers less knockback from attacks.\nBenefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep foods in secondary slot to use, and damage survivors"
+		"en"		"Benefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep foods in secondary slot to use, and damage survivors."
 	}
 	
 	"Menu_ClassesInfectedEngineer"
 	{
-		"en"		"Can only build mini-sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished."
+		"en"		"Gunslinger third critical punch stuns survivor with reduced damage.\nCan only build mini-sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished."
 	}
 	
 	"Menu_ClassesInfectedMedic"
@@ -589,27 +582,27 @@
 	
 	"Menu_ClassesInfectedSniper"
 	{
-		"en"		"Has Bushwacka to crit damage survivors who are under mini-crit effect."
+		"en"		"Has Bushwacka to crit damage survivors who are under mini-crit effect.\nAble to keep wearables in secondary slot to use."
 	}
 	
 	"Menu_ClassesInfectedSpy"
 	{
-		"en"		"Backstabs put the victim into a 'scared' state, slowing and disabling weapon usage for few seconds.\nSurvivors has small resistant while backstabbed"
+		"en"		"Backstabs put the victim into a 'scared' state, slowing and disabling weapon usage for few seconds.\nSurvivors has small resistant while backstabbed."
 	}
 	
 	"Menu_ClassesInfectedSpecialTank"
 	{
-		"en"		"As one of the strongest and brutal infected he has the ability to quickly take down an unsuspecting team of survivors.\n- The Tank has a lot of health which he eventually loses after a while.\n- The Tank starts of fast but is slowed down if damaged by the survivors.\n- The Tank spawns if certain conditions are met."
+		"en"		"As one of the strongest and brutal infected he has the ability to quickly take down an unsuspecting team of survivors.\n- The Tank has a lot of health which he eventually loses after a while.\n- The Tank has full knockback resistance.\n- The Tank starts of fast but is slowed down if damaged by the survivors.\n- The Tank spawns if certain conditions are met."
 	}
 	
 	"Menu_ClassesInfectedSpecialBoomer"
 	{
-		"en"		"He is gross, he is dirty and is not afraid to share this with any unlucky survivors.\n- Upon raging the Boomer explodes, covering survivors close to him in Jarate.\n- Also explodes on death, but weaker and covering less range"
+		"en"		"He is gross, he is dirty and is not afraid to share this with any unlucky survivors.\n- Upon raging the Boomer explodes, covering survivors close to him in Jarate.\n- Also explodes on death, but weaker and covering less range."
 	}
 	
 	"Menu_ClassesInfectedSpecialCharger"
 	{
-		"en"		"His inner rage and insanity has caused him to lose any care for how he uses his body, as long as he can take somebody with it.\n- Using rage to charge the Charger is able to disable and damage survivor for a short period."
+		"en"		"His inner rage and insanity has caused him to lose any care for how he uses his body, as long as he can take somebody with it.\n- Using rage to charge the Charger is able to lock survivor movement and keeps pushing across the area."
 	}
 	
 	"Menu_ClassesInfectedSpecialScreamer"
@@ -619,12 +612,12 @@
 	
 	"Menu_ClassesInfectedSpecialStalker"
 	{
-		"en"		"The Stalker is elusive, being able to get close to survivors and back away in the blink of an eye.\n- The Stalker is always cloaked if not close to any survivor.\n- The Stalker is always cloaked if not close to any survivor.\n- Backstabs deal 50 health damage to a survivor, making it 2.5x stronger than a normal backstab."
+		"en"		"The Stalker is elusive, being able to get close to survivors and back away in the blink of an eye.\n- The Stalker is always cloaked if not close to any survivor.\n- Backstabs deal 50 health damage to a survivor, making it 2.5x stronger than a normal backstab."
 	}
 	
 	"Menu_ClassesInfectedSpecialHunter"
 	{
-		"en"		"The Hunter is a fast being, being very agile they can easily reach beyond the level's obstacles and be hard to get rid off during hectic combat.\n- Using rage, the Hunter will perform a swift leap which can pounce enemies when making physical contact while leaping.\n- Upon pounce, you will be 'stuck' inside the enemy, making you a very dangerous encounter to face when the opponent is alone."
+		"en"		"The Hunter is a fast being, being very agile they can easily reach beyond the level's obstacles.\n- Using rage will perform a swift leap which can pounce enemies when making physical contact while leaping.\n- Upon pounce, you will be 'stuck' inside the enemy, making you a very dangerous encounter to face when the opponent is alone."
 	}
 	
 	"Menu_ClassesInfectedSpecialSmoker"
@@ -634,7 +627,7 @@
 	
 	"Menu_ClassesInfectedSpecialSpitter"
 	{
-		"en"		"The Spitter has a long neck filled with nasty gas survivors couldn't take it.\n- Using rage froze the spitter, spewing out to ground damaging nearby survivors\n- This gives a bigger threat to horde of survivors in small room"
+		"en"		"The Spitter has a long neck filled with nasty gas survivors couldn't take it.\n- Using rage froze the spitter, spewing out to ground damaging nearby survivors.\n- Also releases gas on death.\n- This gives a bigger threat to horde of survivors in small room."
 	}
 	
 	"Menu_ClassesInfectedSpecialJockey"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -36,6 +36,24 @@
 		"en"		"{1}Zombies are resting..."
 	}
 	
+	"Tank_AlreadyHaveOne"
+	{
+		"#format"	"{1:s}"
+		"en"		"{1}Zombies already have a tank."
+	}
+	
+	"Tank_AlreadyOnWay"
+	{
+		"#format"	"{1:s}"
+		"en"		"{1}A zombie tank is already on the way."
+	}
+	
+	"Tank_FrenzyOn"
+	{
+		"#format"	"{1:s}"
+		"en"		"{1}Zombies are frenzied, tanks cannot spawn during frenzy."
+	}
+	
 	"Tank_Chosen"
 	{
 		"#format"	"{1:s},{2:s}"
@@ -56,14 +74,8 @@
 	
 	"Tank_Died"
 	{
-		"#format"	"{1:N},{2:N},{3:d}"
+		"#format"	"{1:N}{2:N}{3:d}"
 		"en"		"The Tank '{1}' has died\nMost damage: {2} ({3})"
-	}
-	
-	"Tank_Multi_Died"
-	{
-		"#format"	"{1:d},{2:N},{3:d}"
-		"en"		"{1} tanks has died\nMost damage: {2} ({3})"
 	}
 	
 	"Carry_Pickup"
@@ -85,7 +97,7 @@
 	
 	"Survivor_Last"
 	{
-		"#format"	"{1:s},{2:s}"
+		"#format"	"{1:s}{2:s}"
 		"en"		"{1}{2} is the last survivor!"
 	}
 	
@@ -378,6 +390,11 @@
 	{
 		"en"		"{green}YOU ARE A JOCKEY:\n{orange}- Call 'MEDIC!' to LEAP into SURVIVORS and control movements! {yellow}(6 second cooldown)"
 	}
+
+	"Melee_Atomizer"
+	{
+		"en"		"{orange}The Atomizer {green}pushes enemies back. {red}Triple jump and airborne minicrits are disabled."
+	}
 	
 	"Melee_CandyCane"
 	{
@@ -411,7 +428,7 @@
 	
 	"Melee_EurekaEffect"
 	{
-		"en"		"{orange}The Eureka Effect {green}increases your buildings' health by 33%%. {red}Teleportation is disabled."
+		"en"		"{orange}The Eureka Effect {green}periodically regenerates metal. {red}Teleportation is disabled."
 	}
 	
 	"Melee_Ubersaw"
@@ -495,14 +512,9 @@
 		"en"		"Infected gain bonuses when sticking together as a hoarde and can enrage which boost health or activate special abilities as special infected.\nEnrage is used by calling for a 'medic' and has a cooldown after use.\nYou may be given the option to respawn as a special infected using 'medic'."
 	}
 	
-	"Menu_ClassesSurvivorsScout"
-	{
-		"en"		"Has 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
-	}
-	
 	"Menu_ClassesSurvivorsSoldier"
 	{
-		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
+		"en"		"Gains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
 	}
 	
 	"Menu_ClassesSurvivorsPyro"
@@ -512,7 +524,7 @@
 	
 	"Menu_ClassesSurvivorsDemoman"
 	{
-		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
+		"en"		"Gains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
 	}
 	
 	"Menu_ClassesSurvivorsHeavy"
@@ -527,47 +539,47 @@
 	
 	"Menu_ClassesSurvivorsMedic"
 	{
-		"en"		"Medigun has a heal rate penalty."
+		"en"		"Medigun has a 60%% heal rate penalty."
 	}
 	
 	"Menu_ClassesSurvivorsSniper"
 	{
-		"en"		"SMG doesn't have to reload.\nJarate slows down Infected.\nHas 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
+		"en"		"SMG doesn't have to reload.\nJarate slows down Infected.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
 	}
 	
 	"Menu_ClassesSurvivorsSpy"
 	{
-		"en"		"Starts with cloak watches and disguise kit.\nHas 25 extra max health.\nGains 2 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon."
+		"en"		"Starts with cloak watches and disguise kit.\nGains 1 primary ammo per kill, this can go beyond the usual maximum capacity of your weapon"
 	}
 	
 	"Menu_ClassesInfectedScout"
 	{
-		"en"		"Has Sandman to slow down survivors.\nAble to keep drinks in secondary slot to use."
+		"en"		"Has Sandman to slow down survivors\nAble to keep drinks in secondary slot to use"
 	}
 	
 	"Menu_ClassesInfectedSoldier"
 	{
-		"en"		"Benefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep banners in secondary slot to use."
+		"en"		"Suffers less knockback from attackers.\nBenefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep banners in secondary slot to use"
 	}
 	
 	"Menu_ClassesInfectedPyro"
 	{
-		"en"		"Has Sharpened Volcano Fragment to ignite survivors.\nAfterburn damage is reduced.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
+		"en"		"Has Sharpened Volcano Fragment to ignite survivors.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
 	}
 	
 	"Menu_ClassesInfectedDemoman"
 	{
-		"en"		"Has Eyelander to damage survivors with long range.\nBenefits less from movement speed and health regeneration bonuses while in a horde."
+		"en"		"Has Eyelander to damage survivors with long range\n.Benefits less from movement speed and health regeneration bonuses while in a horde."
 	}
 	
 	"Menu_ClassesInfectedHeavy"
 	{
-		"en"		"Benefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep foods in secondary slot to use, and damage survivors."
+		"en"		"Blocks fatal attacks, reducing damage to 150.\nSuffers less knockback from attacks.\nBenefits less from movement speed and health regeneration bonuses while in a horde.\nAble to keep foods in secondary slot to use, and damage survivors"
 	}
 	
 	"Menu_ClassesInfectedEngineer"
 	{
-		"en"		"Gunslinger third critical punch stuns survivor with reduced damage.\nCan only build mini-sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished."
+		"en"		"Can only build mini-sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished."
 	}
 	
 	"Menu_ClassesInfectedMedic"
@@ -577,27 +589,27 @@
 	
 	"Menu_ClassesInfectedSniper"
 	{
-		"en"		"Has Bushwacka to crit damage survivors who are under mini-crit effect.\nAble to keep wearables in secondary slot to use."
+		"en"		"Has Bushwacka to crit damage survivors who are under mini-crit effect."
 	}
 	
 	"Menu_ClassesInfectedSpy"
 	{
-		"en"		"Backstabs put the victim into a 'scared' state, slowing and disabling weapon usage for few seconds.\nSurvivors has small resistant while backstabbed."
+		"en"		"Backstabs put the victim into a 'scared' state, slowing and disabling weapon usage for few seconds.\nSurvivors has small resistant while backstabbed"
 	}
 	
 	"Menu_ClassesInfectedSpecialTank"
 	{
-		"en"		"As one of the strongest and brutal infected he has the ability to quickly take down an unsuspecting team of survivors.\n- The Tank has a lot of health which he eventually loses after a while.\n- The Tank has full knockback resistance.\n- The Tank starts of fast but is slowed down if damaged by the survivors.\n- The Tank spawns if certain conditions are met."
+		"en"		"As one of the strongest and brutal infected he has the ability to quickly take down an unsuspecting team of survivors.\n- The Tank has a lot of health which he eventually loses after a while.\n- The Tank starts of fast but is slowed down if damaged by the survivors.\n- The Tank spawns if certain conditions are met."
 	}
 	
 	"Menu_ClassesInfectedSpecialBoomer"
 	{
-		"en"		"He is gross, he is dirty and is not afraid to share this with any unlucky survivors.\n- Upon raging the Boomer explodes, covering survivors close to him in Jarate.\n- Also explodes on death, but weaker and covering less range."
+		"en"		"He is gross, he is dirty and is not afraid to share this with any unlucky survivors.\n- Upon raging the Boomer explodes, covering survivors close to him in Jarate.\n- Also explodes on death, but weaker and covering less range"
 	}
 	
 	"Menu_ClassesInfectedSpecialCharger"
 	{
-		"en"		"His inner rage and insanity has caused him to lose any care for how he uses his body, as long as he can take somebody with it.\n- Using rage to charge the Charger is able to lock survivor movement and keeps pushing across the area."
+		"en"		"His inner rage and insanity has caused him to lose any care for how he uses his body, as long as he can take somebody with it.\n- Using rage to charge the Charger is able to disable and damage survivor for a short period."
 	}
 	
 	"Menu_ClassesInfectedSpecialScreamer"
@@ -607,12 +619,12 @@
 	
 	"Menu_ClassesInfectedSpecialStalker"
 	{
-		"en"		"The Stalker is elusive, being able to get close to survivors and back away in the blink of an eye.\n- The Stalker is always cloaked if not close to any survivor.\n- Backstabs deal 50 health damage to a survivor, making it 2.5x stronger than a normal backstab."
+		"en"		"The Stalker is elusive, being able to get close to survivors and back away in the blink of an eye.\n- The Stalker is always cloaked if not close to any survivor.\n- The Stalker is always cloaked if not close to any survivor.\n- Backstabs deal 50 health damage to a survivor, making it 2.5x stronger than a normal backstab."
 	}
 	
 	"Menu_ClassesInfectedSpecialHunter"
 	{
-		"en"		"The Hunter is a fast being, being very agile they can easily reach beyond the level's obstacles.\n- Using rage will perform a swift leap which can pounce enemies when making physical contact while leaping.\n- Upon pounce, you will be 'stuck' inside the enemy, making you a very dangerous encounter to face when the opponent is alone."
+		"en"		"The Hunter is a fast being, being very agile they can easily reach beyond the level's obstacles and be hard to get rid off during hectic combat.\n- Using rage, the Hunter will perform a swift leap which can pounce enemies when making physical contact while leaping.\n- Upon pounce, you will be 'stuck' inside the enemy, making you a very dangerous encounter to face when the opponent is alone."
 	}
 	
 	"Menu_ClassesInfectedSpecialSmoker"
@@ -622,7 +634,7 @@
 	
 	"Menu_ClassesInfectedSpecialSpitter"
 	{
-		"en"		"The Spitter has a long neck filled with nasty gas survivors couldn't take it.\n- Using rage froze the spitter, spewing out to ground damaging nearby survivors.\n- Also releases gas on death.\n- This gives a bigger threat to horde of survivors in small room."
+		"en"		"The Spitter has a long neck filled with nasty gas survivors couldn't take it.\n- Using rage froze the spitter, spewing out to ground damaging nearby survivors\n- This gives a bigger threat to horde of survivors in small room"
 	}
 	
 	"Menu_ClassesInfectedSpecialJockey"


### PR DESCRIPTION
Atomizer: Was too annoying and used to stall rounds

Removed Triple jump and its airborne attribute (there were no separate attributes)
Added "apply z velocity on damage" attribute

Eureka Effect: Despite many tests, in no situation the buildings' health boost has ever been useful and the metal penalty just makes this melee a liability

Remove buildings' health boost.
Added periodic metal regen (5 every 5 seconds)