### PR TITLE
Make Winger an uncommon weapon.

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -93,7 +93,7 @@
 		
 		"449" // Winger
 		{
-			"rarity"		"common"
+			"rarity"		"uncommon"
 			"model"			"models/weapons/c_models/c_winger_pistol/c_winger_pistol.mdl"
 		}
 		


### PR DESCRIPTION
As it is, Winger feels too good to get, especially at the start of a round as the bonus jump height makes the Scout too slippery for zombies to hit as well as providing unparalleled vertical mobility early that can be abused to accomplish feats such as reaching the first cap at Graveyard without needing to glide on other props or kiting a horde of zombies by jumping between two elevated spots in a cap zone such as the penultimate cap on Cityhunter while still being a competent enough weapon with the slight damage bonus. Making it an uncommon drop should be a fair enough change to the weapon without touching the weapon itself.