### PR TITLE
Additions & Fixes

### DIFF
--- a/addons/sourcemod/scripting/include/superzombiefortress.inc
+++ b/addons/sourcemod/scripting/include/superzombiefortress.inc
@@ -14,7 +14,7 @@ enum WeaponRarity
 /**
  * Forward called when a last survivor is triggered
  *
- * @param	iClient		client whose the last survivor
+ * @param	iClient		Client whose the last survivor
  * @noreturn
  */
 forward void SZF_OnLastSurvivor(int iClient);
@@ -22,8 +22,8 @@ forward void SZF_OnLastSurvivor(int iClient);
 /**
  * Forward called when attacker backstabbed victim
  *
- * @param	iVictim		client whose got backstabbed
- * @param	iAttacker	client whose backstabbed victim
+ * @param	iVictim		Client whose got backstabbed
+ * @param	iAttacker	Client whose backstabbed victim
  * @noreturn
  */
 forward void SZF_OnBackstab(int iVictim, int iAttacker);
@@ -31,7 +31,7 @@ forward void SZF_OnBackstab(int iVictim, int iAttacker);
 /**
  * Forward called when a tank spawns
  *
- * @param	iTank		client whose the tank who spawned
+ * @param	iTank		Client whose the tank who spawned
  * @noreturn
  */
 forward void SZF_OnTankSpawn(int iTank);
@@ -39,9 +39,9 @@ forward void SZF_OnTankSpawn(int iTank);
 /**
  * Forward called when a tank dies
  *
- * @param	iTank		client whose the tank who died
- * @param	iMVP		client whose dealt the most damage to tank, 0 if nobody dealt damage to tank or invalid client
- * @param	iDamage		damage amount from client whose dealt the most damage to tank
+ * @param	iTank		Client whose the tank who died
+ * @param	iMVP		Client whose dealt the most damage to tank, 0 if nobody dealt damage to tank or invalid client
+ * @param	iDamage		Damage amount from client whose dealt the most damage to tank
  * @noreturn
  */
 forward void SZF_OnTankDeath(int iTank, int iMVP, int iDamage);
@@ -49,7 +49,7 @@ forward void SZF_OnTankDeath(int iTank, int iMVP, int iDamage);
 /**
  * Forward called when zombie use quick respawn to become special infected
  *
- * @param	iClient		client whose use the quick respawn to become special infected
+ * @param	iClient		Client whose use the quick respawn to become special infected
  * @noreturn
  */
 forward void SZF_OnQuickSpawnAsSpecialInfected(int iClient);
@@ -57,8 +57,8 @@ forward void SZF_OnQuickSpawnAsSpecialInfected(int iClient);
 /**
  * Forward called when charger charged to stun a survivor
  *
- * @param	iCharger	client whose the charger to stun a survivor
- * @param	iVictim		client whose the victim stunned from the charger
+ * @param	iCharger	Client whose the charger to stun a survivor
+ * @param	iVictim		Client whose the victim stunned from the charger
  * @noreturn
  */
 forward void SZF_OnChargerHit(int iCharger, int iVictim);
@@ -66,8 +66,8 @@ forward void SZF_OnChargerHit(int iCharger, int iVictim);
 /**
  * Forward called when hunter pounced to stun a survivor
  *
- * @param	iHunter		client whose the hunter to stun a survivor
- * @param	iVictim		client whose the victim stunned from the hunter
+ * @param	iHunter		Client whose the hunter to stun a survivor
+ * @param	iVictim		Client whose the victim stunned from the hunter
  * @noreturn
  */
 forward void SZF_OnHunterHit(int iHunter, int iVictim);
@@ -75,9 +75,9 @@ forward void SZF_OnHunterHit(int iHunter, int iVictim);
 /**
  * Forward called when a boomer explodes
  *
- * @param	iBoomer		client whose the boomer explode
- * @param	iClients	array of clients whose jarated from boomer
- * @param	iLength		amount of clients jarated from boomer
+ * @param	iBoomer		Client whose the boomer explode
+ * @param	iClients	Array of clients whose jarated from boomer
+ * @param	iLength		Amount of clients jarated from boomer
  * @noreturn
  */
 forward void SZF_OnBoomerExplode(int iBoomer, int iClients[MAXPLAYERS], int iLength);
@@ -85,18 +85,17 @@ forward void SZF_OnBoomerExplode(int iBoomer, int iClients[MAXPLAYERS], int iLen
 /**
  * Forward called when survivor picked up a weapon
  *
- * @param	iClient		client whose picked up the weapon
+ * @param	iClient		Client whose picked up the weapon
  * @param	iWeapon		Weapon entity whose picked up
  * @param	rarity		Rarity of the weapon
- * @param	iTarget		Prop entity whose picked up
  * @noreturn
  */
-forward void SZF_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity rarity, int iTarget);
+forward void SZF_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity rarity);
 
 /**
  * Forward called when survivor called a rare weapon
  *
- * @param	iClient		client whose called a rare weapon
+ * @param	iClient		Client whose called a rare weapon
  * @noreturn
  */
 forward void SZF_OnWeaponCallout(int iClient);
@@ -105,9 +104,9 @@ forward void SZF_OnWeaponCallout(int iClient);
  * Forward called when plugin need a client name to display in chat to override default name and color
  * plugin uses morecolors.inc to display chat with colors
  *
- * @param	iClient		client whose to get name
- * @param	sName		string to store name
- * @param	iLength		length of string
+ * @param	iClient		Client whose to get name
+ * @param	sName		String to store name
+ * @param	iLength		Length of string
  * @noreturn
  */
 forward void SZF_GetClientName(int iClient, char[] sName, int iLength);
@@ -126,6 +125,16 @@ forward Action SZF_ShouldStartZombie(int iClient);
  * @return	Plugin_Handled to stop music being played, Plugin_Continue otherwise
  */
 forward Action SZF_ShouldAllowMusicPlay();
+
+/**
+ * Forward called when survivor is about to pick up a weapon
+ *
+ * @param	iClient		Client whose picked up the weapon
+ * @param	iTarget		Prop entity whose picked up
+ * @param	rarity		Rarity of the weapon
+ * @return	Plugin_Handled to prevent picking up the weapon, Plugin_Continue otherwise
+ */
+forward Action SZF_ShouldPickupWeapon(int iClient, int iTarget, WeaponRarity rarity);
 
 /**
  * Gets current team survivor team is
@@ -151,7 +160,7 @@ native int SZF_GetLastSurvivor();
 /**
  * Gets client total weapon pickup counts stored in cookies
  *
- * @param	iClient		client whose to get weapon pickup counts
+ * @param	iClient		Client whose to get weapon pickup counts
  * @return	Weapon pickup counts
  * @error	Invalid client or client not in game
  */
@@ -160,7 +169,7 @@ native int SZF_GetWeaponPickupCount(int iClient);
 /**
  * Gets client total rare weapon pickup counts stored in cookies
  *
- * @param	iClient		client whose to get rare weapon pickup counts
+ * @param	iClient		Client whose to get rare weapon pickup counts
  * @return	Rare weapon pickup counts
  * @error	Invalid client or client not in game
  */
@@ -169,7 +178,7 @@ native int SZF_GetWeaponRarePickupCount(int iClient);
 /**
  * Gets client total weapon callout counts stored in cookies
  *
- * @param	iClient		client whose to get weapon callout counts
+ * @param	iClient		Client whose to get weapon callout counts
  * @return	Weapon callout counts
  * @error	Invalid client or client not in game
  */

--- a/addons/sourcemod/scripting/include/superzombiefortress.inc
+++ b/addons/sourcemod/scripting/include/superzombiefortress.inc
@@ -88,9 +88,10 @@ forward void SZF_OnBoomerExplode(int iBoomer, int iClients[MAXPLAYERS], int iLen
  * @param	iClient		client whose picked up the weapon
  * @param	iWeapon		Weapon entity whose picked up
  * @param	rarity		Rarity of the weapon
+ * @param	iTarget		Prop entity whose picked up
  * @noreturn
  */
-forward void SZF_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity rarity);
+forward void SZF_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity rarity, int iTarget);
 
 /**
  * Forward called when survivor called a rare weapon

--- a/addons/sourcemod/scripting/include/superzombiefortress.inc
+++ b/addons/sourcemod/scripting/include/superzombiefortress.inc
@@ -132,7 +132,7 @@ forward Action SZF_ShouldAllowMusicPlay();
  * @param	iClient		Client whose picked up the weapon
  * @param	iTarget		Prop entity whose picked up
  * @param	rarity		Rarity of the weapon
- * @return	Plugin_Handled to prevent picking up the weapon, Plugin_Continue otherwise
+ * @return	Plugin_Handled to prevent picking up the weapon, Plugin_Stop to also prevent calling out rare weapons, Plugin_Continue otherwise
  */
 forward Action SZF_ShouldPickupWeapon(int iClient, int iTarget, WeaponRarity rarity);
 

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -19,7 +19,7 @@
 
 #include "include/superzombiefortress.inc"
 
-#define PLUGIN_VERSION				"4.0.3"
+#define PLUGIN_VERSION				"4.1.0"
 #define PLUGIN_VERSION_REVISION		"manual"
 
 #define TF_MAXPLAYERS		34	//32 clients + 1 for 0/world/console + 1 for replay/SourceTV

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -18,9 +18,11 @@ void ConVar_Init()
 	g_cvTankHealth = CreateConVar("sm_szf_tank_health", "400", "Amount of health the Tank gets per alive survivor", _, true, 10.0);
 	g_cvTankHealthMin = CreateConVar("sm_szf_tank_health_min", "1000", "Minimum amount of health the Tank can spawn with", _, true, 0.0);
 	g_cvTankHealthMax = CreateConVar("sm_szf_tank_health_max", "6000", "Maximum amount of health the Tank can spawn with", _, true, 0.0);
-	g_cvTankTime = CreateConVar("sm_szf_tank_time", "30.0", "Adjusts the damage the Tank takes per second. If the value is 70.0, the Tank will take damage that will make him die (if unhurt by survivors) after 70 seconds. 0 to disable.", _, true, 0.0);
+	g_cvTankTime = CreateConVar("sm_szf_tank_time", "30.0", "Adjusts the damage the Tank takes per second. 0 to disable.", _, true, 0.0);
+	g_cvTankStab = CreateConVar("sm_szf_tank_stab", "0.27", "% Damage dealt to the Tank from a backstab based on max health", _, true, 0.0);
 	g_cvFrenzyChance = CreateConVar("sm_szf_frenzy_chance", "0.0", "% Chance of a random frenzy", _, true, 0.0);
 	g_cvFrenzyTankChance = CreateConVar("sm_szf_frenzy_tank", "0.0", "% Chance of a Tank appearing instead of a frenzy", _, true, 0.0);
+	g_cvStunImmunity = CreateConVar("sm_szf_stun_immunity", "0.0", "How long until the survivor can be stunned again", _, true, 0.0);
 	
 	g_aConVar = new ArrayList(sizeof(ConVarInfo));
 	

--- a/addons/sourcemod/scripting/szf/forward.sp
+++ b/addons/sourcemod/scripting/szf/forward.sp
@@ -7,6 +7,7 @@ static GlobalForward g_hForwardChargerHit;
 static GlobalForward g_hForwardHunterHit;
 static GlobalForward g_hForwardBoomerExplode;
 static GlobalForward g_hForwardWeaponPickup;
+static GlobalForward g_hForwardWeaponPickupPre;
 static GlobalForward g_hForwardWeaponCallout;
 static GlobalForward g_hForwardClientName;
 static GlobalForward g_hForwardStartZombie;
@@ -22,7 +23,8 @@ void Forward_AskLoad()
 	g_hForwardChargerHit = new GlobalForward("SZF_OnChargerHit", ET_Ignore, Param_Cell, Param_Cell);
 	g_hForwardHunterHit = new GlobalForward("SZF_OnHunterHit", ET_Ignore, Param_Cell, Param_Cell);
 	g_hForwardBoomerExplode = new GlobalForward("SZF_OnBoomerExplode", ET_Ignore, Param_Cell, Param_Array, Param_Cell);
-	g_hForwardWeaponPickup = new GlobalForward("SZF_OnWeaponPickup", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
+	g_hForwardWeaponPickup = new GlobalForward("SZF_OnWeaponPickup", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
+	g_hForwardWeaponPickupPre = new GlobalForward("SZF_ShouldPickupWeapon", ET_Single, Param_Cell, Param_Cell, Param_Cell);
 	g_hForwardWeaponCallout = new GlobalForward("SZF_OnWeaponCallout", ET_Ignore, Param_Cell);
 	g_hForwardClientName = new GlobalForward("SZF_GetClientName", ET_Ignore, Param_Cell, Param_String, Param_Cell);
 	g_hForwardStartZombie = new GlobalForward("SZF_ShouldStartZombie", ET_Hook, Param_Cell);
@@ -92,14 +94,24 @@ void Forward_OnBoomerExplode(int iClient, int iClients[MAXPLAYERS], int iCount)
 	Call_Finish();
 }
 
-void Forward_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity nRarity, int iTarget)
+void Forward_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity nRarity)
 {
 	Call_StartForward(g_hForwardWeaponPickup);
 	Call_PushCell(iClient);
 	Call_PushCell(iWeapon);
 	Call_PushCell(nRarity);
-	Call_PushCell(iTarget);
 	Call_Finish();
+}
+
+Action Forward_OnWeaponPickupPre(int iClient, int iTarget, WeaponRarity nRarity)
+{
+	Action action = Plugin_Continue;
+	Call_StartForward(g_hForwardWeaponPickupPre);
+	Call_PushCell(iClient);
+	Call_PushCell(iTarget);
+	Call_PushCell(nRarity);
+	Call_Finish(action);
+	return action;
 }
 
 void Forward_OnWeaponCallout(int iClient)

--- a/addons/sourcemod/scripting/szf/forward.sp
+++ b/addons/sourcemod/scripting/szf/forward.sp
@@ -22,7 +22,7 @@ void Forward_AskLoad()
 	g_hForwardChargerHit = new GlobalForward("SZF_OnChargerHit", ET_Ignore, Param_Cell, Param_Cell);
 	g_hForwardHunterHit = new GlobalForward("SZF_OnHunterHit", ET_Ignore, Param_Cell, Param_Cell);
 	g_hForwardBoomerExplode = new GlobalForward("SZF_OnBoomerExplode", ET_Ignore, Param_Cell, Param_Array, Param_Cell);
-	g_hForwardWeaponPickup = new GlobalForward("SZF_OnWeaponPickup", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
+	g_hForwardWeaponPickup = new GlobalForward("SZF_OnWeaponPickup", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	g_hForwardWeaponCallout = new GlobalForward("SZF_OnWeaponCallout", ET_Ignore, Param_Cell);
 	g_hForwardClientName = new GlobalForward("SZF_GetClientName", ET_Ignore, Param_Cell, Param_String, Param_Cell);
 	g_hForwardStartZombie = new GlobalForward("SZF_ShouldStartZombie", ET_Hook, Param_Cell);
@@ -92,12 +92,13 @@ void Forward_OnBoomerExplode(int iClient, int iClients[MAXPLAYERS], int iCount)
 	Call_Finish();
 }
 
-void Forward_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity nRarity)
+void Forward_OnWeaponPickup(int iClient, int iWeapon, WeaponRarity nRarity, int iTarget)
 {
 	Call_StartForward(g_hForwardWeaponPickup);
 	Call_PushCell(iClient);
 	Call_PushCell(iWeapon);
 	Call_PushCell(nRarity);
+	Call_PushCell(iTarget);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -205,7 +205,18 @@ bool AttemptGrabItem(int iClient)
 		Call_Finish(bAllowPickup);
 	}
 	
-	if (wep.nRarity == WeaponRarity_Pickup)
+	WeaponRarity nRarity = wep.nRarity;
+	Action action = Forward_OnWeaponPickupPre(iClient, iTarget, nRarity);
+	if (action == Plugin_Handled)
+	{
+		bAllowPickup = false;
+	}
+	else if (action == Plugin_Stop)
+	{
+		return false;
+	}
+	
+	if (nRarity == WeaponRarity_Pickup)
 	{
 		if (!bAllowPickup)
 			return false;
@@ -220,7 +231,6 @@ bool AttemptGrabItem(int iClient)
 	}
 	
 	int iIndex = wep.iIndex;
-	WeaponRarity nRarity = wep.nRarity;
 	
 	if (iIndex > -1)
 	{
@@ -447,7 +457,7 @@ void PickupWeapon(int iClient, Weapon wep, int iTarget)
 		g_bTriggerEntity[iTarget] = false;
 	}
 	
-	Forward_OnWeaponPickup(iClient, iWeapon, wep.nRarity, iTarget);
+	Forward_OnWeaponPickup(iClient, iWeapon, wep.nRarity);
 }
 
 public Action Timer_ResetPickup(Handle timer, any iClient)

--- a/addons/sourcemod/scripting/szf/pickupweapons.sp
+++ b/addons/sourcemod/scripting/szf/pickupweapons.sp
@@ -447,7 +447,7 @@ void PickupWeapon(int iClient, Weapon wep, int iTarget)
 		g_bTriggerEntity[iTarget] = false;
 	}
 	
-	Forward_OnWeaponPickup(iClient, iWeapon, wep.nRarity);
+	Forward_OnWeaponPickup(iClient, iWeapon, wep.nRarity, iTarget);
 }
 
 public Action Timer_ResetPickup(Handle timer, any iClient)


### PR DESCRIPTION
- Fixed disguise models staying between rounds and if the plugin is unloaded
- Player no longer respawns if he/she just died as a survivor and respawned before the "You have perished" message
- Fixed viewmodels staying between rounds
- Fixed having 1% chance of random frenzy and tank instead of frenzy even when ConVar set to 0

- Improved code to only use `GetGameTime` once in a function
- Added sm_szf_tank_stab for server owners to control how much backstab damage deals
- Added sm_szf_stun_immunity for server owners to set stun immunity for X seconds after being stunned
- Added kill icon support for destroyed buildings
- Added SZF_ShouldPickupWeapon forward for getting info before picking up a weapon
- Added a slowdown for Spitter's gas