### PR TITLE
Nerf Eyelander, buff Skullcutter

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -667,7 +667,7 @@
 		}
 		"172"	//Scotsman's Skullcutter
 		{
-			"text"		"ScotsmansSkullcutter"
+			"text"		"Melee_ScotsmansSkullcutter"
 			"attrib"	"2 ; 1.3 ; 54 ; 1.0 ; 75 ; 0.9"
 		}
 		"43"	//Killing Gloves of Boxing

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -648,6 +648,28 @@
 			"text"		"Melee_MarketGardener"
 			"attrib"	"58 ; 1.25"
 		}
+		"132"	//Eyelander
+		{
+			"text"		"Melee_Eyelander"
+			"attrib"	"54 ; 0.85 ; 125 ; -40"
+		}
+		"266"	//Horseless Headless Horsemann's Headtaker
+		{
+			"prefab"	"132"
+		}
+		"482"	//Nessie's Nine Iron
+		{
+			"prefab"	"132"
+		}
+		"1082"	//Festive Eyelander
+		{
+			"prefab"	"132"
+		}
+		"172"	//Scotsman's Skullcutter
+		{
+			"text"		"ScotsmansSkullcutter"
+			"attrib"	"2 ; 1.3 ; 54 ; 1.0 ; 75 ; 0.9"
+		}
 		"43"	//Killing Gloves of Boxing
 		{
 			"text"		"Melee_KillingGlovesofBoxing"

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -668,7 +668,7 @@
 		"172"	//Scotsman's Skullcutter
 		{
 			"text"		"Melee_ScotsmansSkullcutter"
-			"attrib"	"54 ; 1.0 ; 75 ; 0.9"
+			"attrib"	"2 ; 1.3"
 		}
 		"43"	//Killing Gloves of Boxing
 		{

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -651,7 +651,7 @@
 		"132"	//Eyelander
 		{
 			"text"		"Melee_Eyelander"
-			"attrib"	"54 ; 0.85 ; 125 ; -40"
+			"attrib"	"54 ; 0.85 ; 125 ; -35"
 		}
 		"266"	//Horseless Headless Horsemann's Headtaker
 		{

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -651,7 +651,7 @@
 		"132"	//Eyelander
 		{
 			"text"		"Melee_Eyelander"
-			"attrib"	"54 ; 0.85 ; 125 ; -35"
+			"attrib"	"54 ; 0.85"
 		}
 		"266"	//Horseless Headless Horsemann's Headtaker
 		{
@@ -668,7 +668,7 @@
 		"172"	//Scotsman's Skullcutter
 		{
 			"text"		"Melee_ScotsmansSkullcutter"
-			"attrib"	"2 ; 1.3 ; 54 ; 1.0 ; 75 ; 0.9"
+			"attrib"	"54 ; 1.0 ; 75 ; 0.9"
 		}
 		"43"	//Killing Gloves of Boxing
 		{

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -406,12 +406,12 @@
 	
 	"Melee_Eyelander"
 	{
-		"en"		"{orange}The Eyelander {red}has its health penalty increased to 35 and makes you move 15%% slower."
+		"en"		"{orange}The Eyelander {red}makes you move 15%% slower."
 	}
 	
 	"Melee_ScotsmansSkullcutter"
 	{
-		"en"		"{orange}The Scotsman's Skullcutter {green}has its damage increased to 30%%. Move speed reduced by 10%% when deployed"
+		"en"		"{orange}The Scotsman's Skullcutter {green}only gives you 10%% move speed penalty when deployed."
 	}
 	
 	"Melee_KillingGlovesofBoxing"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -411,7 +411,7 @@
 	
 	"Melee_ScotsmansSkullcutter"
 	{
-		"en"		"{orange}The Scotsman's Skullcutter {green}only gives you 10%% move speed penalty when deployed."
+		"en"		"{orange}The Scotsman's Skullcutter {green}only gives you 10%% move speed penalty while active."
 	}
 	
 	"Melee_KillingGlovesofBoxing"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -411,7 +411,7 @@
 	
 	"Melee_ScotsmansSkullcutter"
 	{
-		"en"		"{orange}The Scotsman's Skullcutter {green}only gives you 10%% move speed penalty while active."
+		"en"		"{orange}The Scotsman's Skullcutter {green}has its damage bonus increased to 30%%."
 	}
 	
 	"Melee_KillingGlovesofBoxing"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -406,7 +406,7 @@
 	
 	"Melee_Eyelander"
 	{
-		"en"		"{orange}The Eyelander {red}has its health penalty increased to 40 and makes you move 15%% slower."
+		"en"		"{orange}The Eyelander {red}has its health penalty increased to 35 and makes you move 15%% slower."
 	}
 	
 	"Melee_ScotsmansSkullcutter"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -404,6 +404,16 @@
 		"en"		"{orange}The Market Gardener {green}makes you rocket jump 25%% higher."
 	}
 	
+	"Melee_Eyelander"
+	{
+		"en"		"{orange}The Eyelander {red}has its health penalty increased to 40 and makes you move 15%% slower."
+	}
+	
+	"Melee_ScotsmansSkullcutter"
+	{
+		"en"		"{orange}The Scotsman's Skullcutter {green}has its damage increased to 30%%. Move speed reduced by 10%% when deployed"
+	}
+	
 	"Melee_KillingGlovesofBoxing"
 	{
 		"en"		"{orange}The Killing Gloves of Boxing {red}gives 5 seconds of minicrits on kill."


### PR DESCRIPTION
After many games, it's been obvious the melee of choice for demoman has been the Eyelander as it grants uncomprable buffs upon reaching 5 heads, which nullified the need of the player to find a sticky launcher/grenade launcher. This nerf aims at reducing the buff and increase the risks during the head collection process. Plus prevents the demoknight to go lightspeed to avoid the slow and strong zombies as last survivor to regain health from weak zombies.

Eyelander: -15% Speed penalty and -35 Max Health

In order to encourage other melee weapons, I have also included a small buff to Skullcutter. Extra damage and the move speed penalty only applies when the player holds the weapon. Making it a strong early game choice until the player finds a weapon to get rid of the speed penalty.

Skullcutter: 30% damage buff and 10% move speed penalty when active