### PR TITLE
Adjust Health/Ammo Pickup Rules

### DIFF
--- a/addons/sourcemod/gamedata/szf.txt
+++ b/addons/sourcemod/gamedata/szf.txt
@@ -52,6 +52,12 @@
 				"linux"		"@_ZN9CTFPlayer21TeamFortress_SetSpeedEv"
 				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x83\xEC\x1C\x53"
 			}
+			"CTFPlayer::GetMaxAmmo"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer10GetMaxAmmoEii"
+				"windows"	"\x55\x8B\xEC\x8B\x45\x0C\x56\x57\x8B\xF9\x83\xF8\xFF\x75\x2A\xFF\xB7\x2A\x2A\x2A\x2A\xEB\x01\x50\xE8"
+			}
 		}
 		"Offsets"
 		{

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -153,6 +153,18 @@ enum
 	WeaponSlot_BuilderEngie,
 };
 
+enum ETFAmmoType
+{
+	TF_AMMO_DUMMY = 0,	// Dummy index to make the CAmmoDef indices correct for the other ammo types.
+	TF_AMMO_PRIMARY,
+	TF_AMMO_SECONDARY,
+	TF_AMMO_METAL,
+	TF_AMMO_GRENADES1,
+	TF_AMMO_GRENADES2,
+	TF_AMMO_GRENADES3,	// Utility Slot Grenades
+	TF_AMMO_COUNT
+};
+
 enum SZFRoundState
 {
 	SZFRoundState_Setup,

--- a/addons/sourcemod/scripting/szf/sdkcall.sp
+++ b/addons/sourcemod/scripting/szf/sdkcall.sp
@@ -8,6 +8,7 @@ static Handle g_hSDKCallSetSpeed;
 static Handle g_hSDKCallTossJarThink;
 static Handle g_hSDKCallGetBaseEntity;
 static Handle g_hSDKCallGetDefaultItemChargeMeterValue;
+static Handle g_SDKCallGetMaxAmmo;
 
 void SDKCall_Init(GameData hSDKHooks, GameData hTF2, GameData hSZF)
 {
@@ -89,6 +90,15 @@ void SDKCall_Init(GameData hSDKHooks, GameData hTF2, GameData hSZF)
 	g_hSDKCallGetDefaultItemChargeMeterValue = EndPrepSDKCall();
 	if (!g_hSDKCallGetDefaultItemChargeMeterValue)
 		LogError("Failed to create call: CBaseEntity::GetDefaultItemChargeMeterValue");
+
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetFromConf(hSZF, SDKConf_Signature, "CTFPlayer::GetMaxAmmo");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	g_SDKCallGetMaxAmmo = EndPrepSDKCall();
+	if (!g_SDKCallGetMaxAmmo)
+		LogError("Failed to create call: CTFPlayer::GetMaxAmmo");
 }
 
 int SDKCall_GetMaxHealth(int iClient)
@@ -142,4 +152,9 @@ int SDKCall_GetBaseEntity(Address pEnt)
 float SDKCall_GetDefaultItemChargeMeterValue(int iWeapon)
 {
 	return SDKCall(g_hSDKCallGetDefaultItemChargeMeterValue, iWeapon);
+}
+
+int SDKCall_GetMaxAmmo(int client, int ammoType)
+{
+	return SDKCall(g_SDKCallGetMaxAmmo, client, ammoType, -1);
 }


### PR DESCRIPTION
- Allow picking up a health pickup while on fire
- Deny picking up an ammo pickup if ammo is full (Yes taken from [Fortress Royale](https://github.com/Mikusch/fortress-royale/blob/master/addons/sourcemod/scripting/royale/loot/loot_callbacks.sp#L172-L196 "fortress-royale/loot_callbacks.sp at master  Mikusch/fortress-royale"))