### PR TITLE
Add support for unconventional static weapons

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -610,6 +610,12 @@
 		
 		//Those weapons can only be spawned using szf_weapon_static
 		
+		"228" // Black Box
+		{
+			"rarity"		"static"
+			"model"			"models/weapons/c_models/c_blackbox/c_blackbox.mdl"
+		}
+		
 		"237" // Rocket Jumper
 		{
 			"rarity"		"static"

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -608,18 +608,18 @@
 			"sound"			"items/powerup_pickup_base.wav"
 		}
 		
-		//Those models can only be spawned using szf_weapon_static
+		//Those weapons can only be spawned using szf_weapon_static
 		
 		"237" // Rocket Jumper
 		{
 			"rarity"		"static"
-			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
+			"model"			"models/weapons/c_models/c_rocketjumper/c_rocketjumper.mdl"
 		}
 		
 		"265" // Sticky Jumper
 		{
 			"rarity"		"static"
-			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
+			"model"			"models/weapons/c_models/c_sticky_jumper/c_sticky_jumper.mdl"
 		}
 	}
 	

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -608,18 +608,18 @@
 			"sound"			"items/powerup_pickup_base.wav"
 		}
 		
-		//Those weapons can only be spawned using szf_weapon_static
+		//Those models can only be spawned using szf_weapon_static
 		
 		"237" // Rocket Jumper
 		{
 			"rarity"		"static"
-			"model"			"models/weapons/c_models/c_rocketjumper/c_rocketjumper.mdl"
+			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
 		}
 		
 		"265" // Sticky Jumper
 		{
 			"rarity"		"static"
-			"model"			"models/weapons/c_models/c_sticky_jumper/c_sticky_jumper.mdl"
+			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
 		}
 	}
 	

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -27,7 +27,6 @@
 			{
 				"attrib" 		"79 ; 0.3"	//60 ammo max
 			}
-			
 		}
 		
 		"415" // Reserve Shooter
@@ -588,8 +587,7 @@
 			"color"			"150 255 150 255"
 			"sound"			"ui/item_heavy_gun_pickup.wav"
 		}
-		
-		
+			
 		"-1" // Minicrits buff
 		{
 			"rarity"		"pickup"
@@ -608,6 +606,20 @@
 			"color"			"150 0 0 255"
 			"height_offset"	"15.0"
 			"sound"			"items/powerup_pickup_base.wav"
+		}
+		
+		//Those models can only be spawned using szf_weapon_static
+		
+		"237" // Rocket Jumper
+		{
+			"rarity"		"static"
+			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
+		}
+		
+		"265" // Sticky Jumper
+		{
+			"rarity"		"static"
+			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
 		}
 	}
 	

--- a/addons/sourcemod/scripting/include/superzombiefortress.inc
+++ b/addons/sourcemod/scripting/include/superzombiefortress.inc
@@ -8,6 +8,7 @@ enum WeaponRarity
 	WeaponRarity_Common,
 	WeaponRarity_Uncommon,
 	WeaponRarity_Rare,
+	WeaponRarity_Static,
 	WeaponRarity_Pickup,
 };
 

--- a/addons/sourcemod/scripting/szf/config.sp
+++ b/addons/sourcemod/scripting/szf/config.sp
@@ -80,6 +80,7 @@ ArrayList Config_LoadWeaponData()
 		mRarity.SetValue("common", WeaponRarity_Common);
 		mRarity.SetValue("uncommon", WeaponRarity_Uncommon);
 		mRarity.SetValue("rare", WeaponRarity_Rare);
+		mRarity.SetValue("static", WeaponRarity_Static);
 		mRarity.SetValue("pickup", WeaponRarity_Pickup);
 	}
 	

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -338,9 +338,12 @@ stock void FireRelay(const char[] sInput, const char[] sTargetName1, const char[
 
 stock void TF2_EndRound(TFTeam nTeam)
 {
-	int iIndex = CreateEntityByName("game_round_win");
-	DispatchKeyValue(iIndex, "force_map_reset", "1");
-	DispatchSpawn(iIndex);
+	int iIndex = FindEntityByClassname(-1, "game_round_win");
+	if (iIndex == -1)
+	{
+		iIndex = CreateEntityByName("game_round_win");
+		DispatchSpawn(iIndex);
+	}
 	
 	if (iIndex == -1)
 	{

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -338,12 +338,9 @@ stock void FireRelay(const char[] sInput, const char[] sTargetName1, const char[
 
 stock void TF2_EndRound(TFTeam nTeam)
 {
-	int iIndex = FindEntityByClassname(-1, "game_round_win");
-	if (iIndex == -1)
-	{
-		iIndex = CreateEntityByName("game_round_win");
-		DispatchSpawn(iIndex);
-	}
+	int iIndex = CreateEntityByName("game_round_win");
+	DispatchKeyValue(iIndex, "force_map_reset", "1");
+	DispatchSpawn(iIndex);
 	
 	if (iIndex == -1)
 	{


### PR DESCRIPTION
Allows szf_weapon_static to place weapons such as the Rocket Jumper and Sticky Jumper. 

Adds the "static" rarity in the weapons config, only szf_weapon_static can spawn those weapons.