### PR TITLE
Fix Dispenser giving ammo again after re-deploy

### DIFF
--- a/addons/sourcemod/scripting/szf/event.sp
+++ b/addons/sourcemod/scripting/szf/event.sp
@@ -465,11 +465,14 @@ public Action Event_PlayerBuiltObject(Event event, const char[] name, bool dontB
 	int iEntity = event.GetInt("index");
 	TFObjectType nObjectType = view_as<TFObjectType>(event.GetInt("object"));
 	   
-	if (nObjectType == TFObject_Dispenser && IsSurvivor(iClient) && !GetEntProp(iEntity, Prop_Send, "m_bCarryDeploy"))
+	if (nObjectType == TFObject_Dispenser && IsSurvivor(iClient))
 	{
+		if (!GetEntProp(iEntity, Prop_Send, "m_bCarryDeploy"))
+		{
+			int iMaxHealth = GetEntProp(iEntity, Prop_Send, "m_iMaxHealth");
+			SetEntProp(iEntity, Prop_Send, "m_iMaxHealth", iMaxHealth * 2);	// Double max health (default level 1 is 150)
+		}
 		SetEntProp(iEntity, Prop_Send, "m_bCarried", 1);	// Disable healing/ammo and upgrading
-		int iMaxHealth = GetEntProp(iEntity, Prop_Send, "m_iMaxHealth");
-		SetEntProp(iEntity, Prop_Send, "m_iMaxHealth", iMaxHealth * 2);	// Double max health (default level 1 is 150)
 	}
 	
 	return Plugin_Continue;


### PR DESCRIPTION
Event_PlayerBuiltObject had an issue where it would no longer disable the ammo after redeploy.
This was being abused, so we looked into it.
The reason this was an issue, was because the health had to not be set again, so this needed an inner if, instead of an all-encompassing if.