### PR TITLE
Hunter: Longer Pounce Cooldown

### DIFF
--- a/addons/sourcemod/configs/szf/classes.cfg
+++ b/addons/sourcemod/configs/szf/classes.cfg
@@ -379,7 +379,7 @@
 			"viewmodel_height"	"-4.0"
 			
 			"sound_spawn"		"szf/music/bacteria/hunterbacterias.mp3"
-			"ragecooldown"		"3"
+			"ragecooldown"		"6"
 			"callback_rage"		"Infected_DoHunterJump"
 			"callback_anim"		"Infected_OnHunterAnim"
 			"callback_touch"	"Infected_OnHunterTouch"


### PR DESCRIPTION
Increases rage cooldown by three seconds (aka substantially increasing cooldown on missing a pounce). Probably one of the best special infected currently in the mode for being able to lock down and potentially kill a survivor by themselves. Only having a three second cooldown on missing a pounce is too generous, especially compared to Jockey which has a longer cooldown on miss with a similar, but more situational power.