### PR TITLE
Allow equip Hardy Laurel

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1923,6 +1923,15 @@ void HandleSurvivorLoadout(int iClient)
 		}
 	}
 	
+	//Remove rome vision
+	int iWearable = INVALID_ENT_REFERENCE;
+	while ((iWearable = FindEntityByClassname(iWearable, "tf_wearable*")) != INVALID_ENT_REFERENCE)
+	{
+		if (GetEntPropEnt(iWearable, Prop_Send, "m_hOwnerEntity") == iClient || GetEntPropEnt(iWearable, Prop_Send, "moveparent") == iClient)
+			if (0 <= GetEntProp(iWearable, Prop_Send, "m_iItemDefinitionIndex") < 0xFFFF)
+				RemoveWeaponVision(iWearable, TF_VISION_FILTER_ROME);
+	}
+	
 	int iMelee = TF2_GetItemInSlot(iClient, WeaponSlot_Melee);
 	if (iMelee > MaxClients)
 	{
@@ -2476,8 +2485,6 @@ Action OnGiveNamedItem(int iClient, const char[] sClassname, int iIndex)
 	Action iAction = Plugin_Continue;
 	if (iTeam == TFTeam_Survivor)
 	{
-		float flVal;
-		
 		if (iSlot < WeaponSlot_Melee)
 		{
 			iAction = Plugin_Handled;
@@ -2485,11 +2492,6 @@ Action OnGiveNamedItem(int iClient, const char[] sClassname, int iIndex)
 		else if (GetClassVoodooItemDefIndex(iClass) == iIndex)
 		{
 			//Survivors are not zombies
-			iAction = Plugin_Handled;
-		}
-		else if (TF2_DefIndexFindAttribute(iIndex, ATTRIB_VISION, flVal) && RoundToNearest(flVal) & TF_VISION_FILTER_ROME)
-		{
-			//Rome vision is used for zombie custom model disguise detour fix, dont give vision to survivor
 			iAction = Plugin_Handled;
 		}
 	}

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -191,7 +191,18 @@ stock void AddWeaponVision(int iWeapon, int iFlag)
 	//Get current flag and add into it
 	float flVal = float(TF_VISION_FILTER_NONE);
 	TF2_WeaponFindAttribute(iWeapon, ATTRIB_VISION, flVal);
-	flVal = float(RoundToNearest(flVal)|iFlag);
+	flVal = float(RoundToNearest(flVal) | iFlag);
+	TF2Attrib_SetByDefIndex(iWeapon, ATTRIB_VISION, flVal);
+}
+
+stock void RemoveWeaponVision(int iWeapon, int iFlag)
+{
+	//If have vision, get current flag and remove it
+	float flVal = float(TF_VISION_FILTER_NONE);
+	if (!TF2_WeaponFindAttribute(iWeapon, ATTRIB_VISION, flVal))
+		return;
+	
+	flVal = float(RoundToNearest(flVal) & ~iFlag);
 	TF2Attrib_SetByDefIndex(iWeapon, ATTRIB_VISION, flVal);
 }
 


### PR DESCRIPTION
Hardy Laurel was restricted because rome vision was used for spy disguising as special infected with custom model, but we can allow equip Hardy Laurel, just without rome vision attribute.