### PR TITLE
Half Zatochi change

### DIFF
--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -666,7 +666,7 @@
 		"357"	//Half Zatochi
 		{
 			"text"		"Melee_HalfZatochi"
-			"attrib"	"855 ; 10.0"
+			"attrib"	"125 ; 25.0"
 		}
 		"416"	//Market Gardener
 		{


### PR DESCRIPTION
Half Zatoichi has been unusable ever since being given out GRU's attribute, which gradually decreases your max. health to 100 while active.
This change sets it to -25 permanently, which should also decrease amount of healing