### PR TITLE
Reset Jockey target

### DIFF
--- a/addons/sourcemod/configs/szf/classes.cfg
+++ b/addons/sourcemod/configs/szf/classes.cfg
@@ -459,6 +459,7 @@
 			"callback_think"	"Infected_OnJockeyThink"
 			"callback_touch"	"Infected_OnJockeyTouch"
 			"callback_anim"		"Infected_OnJockeyAnim"
+			"callback_death"	"Infected_OnJockeyDeath"
 			
 			"weapon"
 			{

--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -893,3 +893,8 @@ public Action Infected_OnJockeyAnim(int iClient, PlayerAnimEvent_t &nAnim, int &
 	
 	return Plugin_Continue;
 }
+
+public void Infected_OnJockeyDeath(int iClient, int iKiller, int iAssist)
+{
+	g_iJockeyTarget[iClient] = 0;
+}


### PR DESCRIPTION
Adds OnDeath callback for Jockey infected which resets target.
OnThink callback is never called after infected dies. This means that Jockey's target is never reset when the jockey is killed and his target survives. And when the same player becomes Jockey again, it will immediately teleport to its previous target if it's alive and not infected.