### PR TITLE
Buff Last Survivor

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1604,6 +1604,7 @@ void CheckLastSurvivor(int iIgnoredClient = 0)
 		return;
 	
 	TF2_AddCondition(iLastSurvivor, TFCond_KingRune, TFCondDuration_Infinite);
+	TF2_AddCondition(iLastSurvivor, TFCond_DefenseBuffNoCritBlock, TFCondDuration_Infinite);
 	SetEntityHealth(iLastSurvivor, SDKCall_GetMaxHealth(iLastSurvivor));
 	
 	g_bLastSurvivor = true;


### PR DESCRIPTION
The majority of players feel like last survivor dies far too quickly, so let's try adding a 35% damage reduction. Critical hits still deal full damage.