### PR TITLE
Fix the Disciplinary Action not hitting teammates

### DIFF
--- a/addons/sourcemod/scripting/szf/dhook.sp
+++ b/addons/sourcemod/scripting/szf/dhook.sp
@@ -283,6 +283,11 @@ public MRESReturn DHook_DoSwingTraceInternalPre(int iMelee, DHookReturn hReturn,
 	if (!g_cvMeleeIgnoreTeammates.BoolValue)
 		return MRES_Ignored;
 	
+	// Ignore weapons with "speed buff ally" attribute
+	float flSpeedBuffAlly = 0.0;
+	if (TF2_WeaponFindAttribute(iMelee, 251, flSpeedBuffAlly) && flSpeedBuffAlly)
+		return MRES_Ignored;
+	
 	// Enable MvM for this function for melee trace hack
 	GameRules_SetProp("m_bPlayingMannVsMachine", true);
 	
@@ -309,6 +314,11 @@ public MRESReturn DHook_DoSwingTraceInternalPre(int iMelee, DHookReturn hReturn,
 public MRESReturn DHook_DoSwingTraceInternalPost(int iMelee, DHookReturn hReturn, DHookParam hParams)
 {
 	if (!g_cvMeleeIgnoreTeammates.BoolValue)
+		return MRES_Ignored;
+	
+	// Ignore weapons with "speed buff ally" attribute
+	float flSpeedBuffAlly = 0.0;
+	if (TF2_WeaponFindAttribute(iMelee, 251, flSpeedBuffAlly) && flSpeedBuffAlly)
 		return MRES_Ignored;
 	
 	// Disable MvM so there are no lingering effects


### PR DESCRIPTION
87a2dc8bb61ea1b66e94d483d09679d6cc0b4141 allowed all melee hits to ignore teammates, but this broke the Soldier's whip speed boost.

This PR reverts the Disciplinary Action to the previous behavior.