### PR TITLE
Buff Jockey move target speed

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -365,6 +365,8 @@ ConVar g_cvTankHealthMin;
 ConVar g_cvTankHealthMax;
 ConVar g_cvTankTime;
 ConVar g_cvTankStab;
+ConVar g_cvJockeyMovementVictim;
+ConVar g_cvJockeyMovementAttacker;
 ConVar g_cvFrenzyChance;
 ConVar g_cvFrenzyTankChance;
 ConVar g_cvStunImmunity;

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -20,6 +20,8 @@ void ConVar_Init()
 	g_cvTankHealthMax = CreateConVar("sm_szf_tank_health_max", "6000", "Maximum amount of health the Tank can spawn with", _, true, 0.0);
 	g_cvTankTime = CreateConVar("sm_szf_tank_time", "30.0", "Adjusts the damage the Tank takes per second. 0 to disable.", _, true, 0.0);
 	g_cvTankStab = CreateConVar("sm_szf_tank_stab", "0.27", "% Damage dealt to the Tank from a backstab based on max health", _, true, 0.0);
+	g_cvJockeyMovementVictim = CreateConVar("sm_szf_jockey_movement_victim", "0.25", "Percentage of movement speed applied to victim from jockey grab", _, true, 0.0);
+	g_cvJockeyMovementAttacker = CreateConVar("sm_szf_jockey_movement_attacker", "0.75", "Percentage of movement speed applied to jockey during grab", _, true, 0.0);
 	g_cvFrenzyChance = CreateConVar("sm_szf_frenzy_chance", "0.0", "% Chance of a random frenzy", _, true, 0.0);
 	g_cvFrenzyTankChance = CreateConVar("sm_szf_frenzy_tank", "0.0", "% Chance of a Tank appearing instead of a frenzy", _, true, 0.0);
 	g_cvStunImmunity = CreateConVar("sm_szf_stun_immunity", "0.0", "How long until the survivor can be stunned again", _, true, 0.0);

--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -834,8 +834,8 @@ public void Infected_OnJockeyThink(int iClient, int &iButtons)
 			GetClientEyeAngles(iTarget, vecTargetEye);
 			vecJockeyEye[2] = 0.0;
 			vecTargetEye[2] = 0.0;
-			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * 0.75);
-			AnglesToVelocity(vecTargetEye, vecTargetVel, flSpeed * 0.25);
+			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * 0.100);
+			AnglesToVelocity(vecTargetEye, vecTargetVel, flSpeed * 0.0);
 			
 			AddVectors(vecJockeyVel, vecTargetVel, vecFinalVel);
 			TeleportEntity(iTarget, NULL_VECTOR, NULL_VECTOR, vecFinalVel);

--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -834,8 +834,8 @@ public void Infected_OnJockeyThink(int iClient, int &iButtons)
 			GetClientEyeAngles(iTarget, vecTargetEye);
 			vecJockeyEye[2] = 0.0;
 			vecTargetEye[2] = 0.0;
-			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * 1.0);
-			AnglesToVelocity(vecTargetEye, vecTargetVel, flSpeed * 0.0);
+			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * g_cvJockeyMovementAttacker.FloatValue);
+			AnglesToVelocity(vecTargetEye, vecTargetVel, flSpeed * g_cvJockeyMovementVictim.FloatValue);
 			
 			AddVectors(vecJockeyVel, vecTargetVel, vecFinalVel);
 			TeleportEntity(iTarget, NULL_VECTOR, NULL_VECTOR, vecFinalVel);

--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -834,7 +834,7 @@ public void Infected_OnJockeyThink(int iClient, int &iButtons)
 			GetClientEyeAngles(iTarget, vecTargetEye);
 			vecJockeyEye[2] = 0.0;
 			vecTargetEye[2] = 0.0;
-			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * 0.100);
+			AnglesToVelocity(vecJockeyEye, vecJockeyVel, flSpeed * 1.0);
 			AnglesToVelocity(vecTargetEye, vecTargetVel, flSpeed * 0.0);
 			
 			AddVectors(vecJockeyVel, vecTargetVel, vecFinalVel);


### PR DESCRIPTION
If survivor is facing direction that jockey is not looking at, both players will stand still. This change will give full control of the player and Jockey will become a bit more similar to L4D with the ability to take the survivor away from the rest or to a deadly environment, bringing more tactics for this special infected.