### PR TITLE
Reset players' 'started as zombie' timestamp when joining

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -651,6 +651,8 @@ void GetMapSettings()
 public void OnClientPutInServer(int iClient)
 {
 	g_iDamageZombie[iClient] = 0;
+	g_flTimeStartAsZombie[iClient] = 0.0;
+	g_bWaitingForTeamSwitch[iClient] = false;
 	
 	if (!g_bEnabled)
 		return;
@@ -673,8 +675,6 @@ public void OnClientDisconnect(int iClient)
 	Sound_EndMusic(iClient);
 	DropCarryingItem(iClient);
 	CheckLastSurvivor(iClient);
-	
-	g_bWaitingForTeamSwitch[iClient] = false;
 	
 	Weapons_ClientDisconnect(iClient);
 }


### PR DESCRIPTION
Fixes a specific case of players being accidentally flagged as skipping playing as infected when taking someone else's spot in the server (who actually likely skipped), then joining spectator.

This probably won't solve all accidental flagging, but may as well do it for this case.

Also moves resetting `g_bWaitingForTeamSwitch` from `OnClientDisconnect` to `OnClientPutInServer` so everything is in the same place.