### PR TITLE
Charger: remove inconsistent end-of-charge crit

### DIFF
--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -383,6 +383,9 @@ public void Infected_OnChargerThink(int iClient, int &iButtons)
 		AnglesToVelocity(vecAngles, vecVel, 75.0);
 		AddVectors(vecOrigin, vecVel, vecOrigin);
 		
+		//Keep the charge meter at 100.0, so you never really run out of charge
+		SetEntPropFloat(iClient, Prop_Send, "m_flChargeMeter", 100.0);
+		
 		//Force push charger at stupid amount of speed, WEEEEEEEEEEEEEEEEEE
 		const float flSpeed = 520.0;
 		AnglesToVelocity(vecAngles, vecVel, flSpeed);


### PR DESCRIPTION
The Charger can sometimes crit after charging, this is because of SZF not accounting for the Demoman's charge meter, that is active even if you don't have a shield. It will always empty out before the charge is finished, if it empties out right before the Charger is allowed to swing their melee, it will crit. It may run out of charge sooner for whatever reason and that makes the melee swing not crit.

The critting was deemed to be a bug, so we're removing it by keeping the charge meter that is invisible to players at 100% during the charge.