### PR TITLE
Allow disguise as anyone except Spy

### DIFF
--- a/addons/sourcemod/gamedata/szf.txt
+++ b/addons/sourcemod/gamedata/szf.txt
@@ -22,12 +22,6 @@
 				"linux"		"@_ZN9CTFPlayer16DoAnimationEventE17PlayerAnimEvent_ti"
 				"windows"	"\x55\x8B\xEC\x51\x53\x56\x8B\x35\x2A\x2A\x2A\x2A\x8B\xD9\x8B\xCE"
 			}
-			"CTFPlayerShared::DetermineDisguiseWeapon"
-			{
-				"library"	"server"
-				"linux"		"@_ZN15CTFPlayerShared23DetermineDisguiseWeaponEb"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x1C\x53\x8B\xD9\xC7\x45\xFC\x00\x00\x00\x00"
-			}
 			"CGameUI::Deactivate"
 			{
 				"library"	"server"
@@ -85,11 +79,6 @@
 				"linux"		"498"
 				"windows"	"491"
 			}
-			"CBaseEntity::GetBaseEntity"
-			{
-				"linux" 	"6"
-				"windows" 	"5"
-			}
 			"CBaseEntity::GetDefaultItemChargeMeterValue"
 			{
 				"linux"		"197"
@@ -99,11 +88,6 @@
 			{
 				"linux"		"4"
 				"windows"	"4"
-			}
-			"CTFPlayerShared::m_pOuter"
-			{
-				"linux"		"396"
-				"windows"	"396"
 			}
 		}
 		"Functions"

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -2037,8 +2037,14 @@ void OnClientDisguise(int iClient)
 	}
 	else
 	{
+		// Make sure all wearables is removed, can happen when no disguise target
+		int iWearable = INVALID_ENT_REFERENCE;
+		while ((iWearable = FindEntityByClassname(iWearable, "tf_wearable*")) > MaxClients)
+			if (GetEntPropEnt(iWearable, Prop_Send, "m_hOwnerEntity") == iClient && GetEntProp(iWearable, Prop_Send, "m_bDisguiseWearable"))
+				TF2_RemoveWearable(iClient, iWearable);
+		
 		// Should be disguising as default class, give zombie weapon and cosmetics
-		int iWearable = CreateVoodooWearable(iClient, nClass);
+		iWearable = CreateVoodooWearable(iClient, nClass);
 		SetEntProp(iWearable, Prop_Send, "m_bDisguiseWearable", true);	// Must be set before equip
 		TF2_EquipWeapon(iClient, iWearable);
 		

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -2018,7 +2018,7 @@ void OnClientDisguise(int iClient)
 	
 	if (nClass == TFClass_Spy)
 	{
-		// You are not supposed to be here
+		// You're not supposed to be here
 		TF2_RemovePlayerDisguise(iClient);
 		return;
 	}

--- a/addons/sourcemod/scripting/szf/classes.sp
+++ b/addons/sourcemod/scripting/szf/classes.sp
@@ -288,6 +288,19 @@ stock int GetZombieClassCount()
 	return g_iZombieClassCount;
 }
 
+stock int GetZombieMeleeIndex(TFClassType nClass)
+{
+	int iPos;
+	WeaponClasses weapon;
+	while (g_ZombieClasses[nClass].GetWeapon(iPos, weapon))
+	{
+		if (TF2Econ_GetItemLoadoutSlot(weapon.iIndex, nClass) == WeaponSlot_Melee)
+			return weapon.iIndex;
+	}
+	
+	return -1;
+}
+
 stock bool IsValidInfected(Infected nInfected)
 {
 	return g_InfectedClasses[nInfected].bEnabled;

--- a/addons/sourcemod/scripting/szf/classes.sp
+++ b/addons/sourcemod/scripting/szf/classes.sp
@@ -290,15 +290,7 @@ stock int GetZombieClassCount()
 
 stock int GetZombieMeleeIndex(TFClassType nClass)
 {
-	int iPos;
-	WeaponClasses weapon;
-	while (g_ZombieClasses[nClass].GetWeapon(iPos, weapon))
-	{
-		if (TF2Econ_GetItemLoadoutSlot(weapon.iIndex, nClass) == WeaponSlot_Melee)
-			return weapon.iIndex;
-	}
-	
-	return -1;
+	return g_ZombieClasses[nClass].GetWeaponSlotIndex(WeaponSlot_Melee);
 }
 
 stock bool IsValidInfected(Infected nInfected)

--- a/addons/sourcemod/scripting/szf/event.sp
+++ b/addons/sourcemod/scripting/szf/event.sp
@@ -294,8 +294,6 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		else
 			Sound_PlayInfectedVo(iVictim, g_nInfected[iVictim], SoundVo_Death);
 		
-		Classes_SetClient(iVictim, Infected_None);
-		
 		//10%
 		if (IsValidSurvivor(iKillers[0]) && !GetRandomInt(0, 9) && g_nRoundState == SZFRoundState_Active)
 			g_bSpawnAsSpecialInfected[iVictim] = true;

--- a/addons/sourcemod/scripting/szf/sdkcall.sp
+++ b/addons/sourcemod/scripting/szf/sdkcall.sp
@@ -6,7 +6,6 @@ static Handle g_hSDKCallGiveNamedItem;
 static Handle g_hSDKCallGetLoadoutItem;
 static Handle g_hSDKCallSetSpeed;
 static Handle g_hSDKCallTossJarThink;
-static Handle g_hSDKCallGetBaseEntity;
 static Handle g_hSDKCallGetDefaultItemChargeMeterValue;
 
 void SDKCall_Init(GameData hSDKHooks, GameData hTF2, GameData hSZF)
@@ -49,7 +48,7 @@ void SDKCall_Init(GameData hSDKHooks, GameData hTF2, GameData hSZF)
 	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
 	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
 	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_ByValue);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
+	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
 	g_hSDKCallGiveNamedItem = EndPrepSDKCall();
 	if (!g_hSDKCallGiveNamedItem)
 		LogError("Failed to create call: CTFPlayer::GiveNamedItem");
@@ -75,13 +74,6 @@ void SDKCall_Init(GameData hSDKHooks, GameData hTF2, GameData hSZF)
 	g_hSDKCallTossJarThink = EndPrepSDKCall();
 	if (!g_hSDKCallTossJarThink)
 		LogError("Failed to create call: CTFJar::TossJarThink");
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hSZF, SDKConf_Virtual, "CBaseEntity::GetBaseEntity");
-	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
-	g_hSDKCallGetBaseEntity = EndPrepSDKCall();
-	if (!g_hSDKCallGetBaseEntity)
-		LogError("Failed to create call: CBaseEntity::GetBaseEntity");
 	
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(hSZF, SDKConf_Virtual, "CBaseEntity::GetDefaultItemChargeMeterValue");
@@ -111,12 +103,12 @@ int SDKCall_GetEquippedWearable(int iClient, int iSlot)
 	return SDKCall(g_hSDKCallGetEquippedWearable, iClient, iSlot);
 }
 
-Address SDKCall_GiveNamedItem(int iClient, const char[] sClassname, int iSubType, Address pItem, bool bForce = false, bool bSkipHook = true)
+int SDKCall_GiveNamedItem(int iClient, const char[] sClassname, int iSubType, Address pItem, bool bForce = false, bool bSkipHook = true)
 {
 	g_bGiveNamedItemSkip = bSkipHook;
-	Address pEntity = SDKCall(g_hSDKCallGiveNamedItem, iClient, sClassname, iSubType, pItem, bForce);
+	int iEntity = SDKCall(g_hSDKCallGiveNamedItem, iClient, sClassname, iSubType, pItem, bForce);
 	g_bGiveNamedItemSkip = false;
-	return pEntity;
+	return iEntity;
 }
 
 Address SDKCall_GetLoadoutItem(int iClient, TFClassType iClass, int iSlot)
@@ -132,11 +124,6 @@ void SDKCall_SetSpeed(int iClient)
 void SDKCall_TossJarThink(int iEntity)
 {
 	SDKCall(g_hSDKCallTossJarThink, iEntity);
-}
-
-int SDKCall_GetBaseEntity(Address pEnt)
-{
-	return SDKCall(g_hSDKCallGetBaseEntity, pEnt);
 }
 
 float SDKCall_GetDefaultItemChargeMeterValue(int iWeapon)

--- a/addons/sourcemod/scripting/szf/sdkhook.sp
+++ b/addons/sourcemod/scripting/szf/sdkhook.sp
@@ -34,7 +34,7 @@ void SDKHook_HookClient(int iClient)
 
 void SDKHook_UnhookClient(int iClient)
 {
-	SDKHook(iClient, SDKHook_PreThink, Client_PreThink);
+	SDKUnhook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKUnhook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
 	SDKUnhook(iClient, SDKHook_Touch, Client_Touch);
 	SDKUnhook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);

--- a/addons/sourcemod/scripting/szf/sdkhook.sp
+++ b/addons/sourcemod/scripting/szf/sdkhook.sp
@@ -1,3 +1,6 @@
+static int g_iOffsetDisguiseCompleteTime;
+static float g_flDisguiseCompleteTime;
+
 void SDKHook_OnEntityCreated(int iEntity, const char[] sClassname)
 {
 	if (StrEqual(sClassname, "prop_dynamic") && g_nRoundState == SZFRoundState_Active)
@@ -22,6 +25,7 @@ void SDKHook_OnEntityCreated(int iEntity, const char[] sClassname)
 
 void SDKHook_HookClient(int iClient)
 {
+	SDKHook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKHook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
 	SDKHook(iClient, SDKHook_Touch, Client_Touch);
 	SDKHook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
@@ -30,15 +34,28 @@ void SDKHook_HookClient(int iClient)
 
 void SDKHook_UnhookClient(int iClient)
 {
+	SDKHook(iClient, SDKHook_PreThink, Client_PreThink);
 	SDKUnhook(iClient, SDKHook_PreThinkPost, Client_PreThinkPost);
 	SDKUnhook(iClient, SDKHook_Touch, Client_Touch);
 	SDKUnhook(iClient, SDKHook_OnTakeDamage, Client_OnTakeDamage);
 	SDKUnhook(iClient, SDKHook_GetMaxHealth, Client_GetMaxHealth);
 }
 
+public Action Client_PreThink(int iClient)
+{
+	if (!g_iOffsetDisguiseCompleteTime)
+		g_iOffsetDisguiseCompleteTime = FindSendPropInfo("CTFPlayer", "m_unTauntSourceItemID_High") + 4;
+	
+	g_flDisguiseCompleteTime = GetEntDataFloat(iClient, g_iOffsetDisguiseCompleteTime);
+	return Plugin_Continue;
+}
+
 public void Client_PreThinkPost(int iClient)
 {
 	UpdateClientCarrying(iClient);
+	
+	if (g_flDisguiseCompleteTime && !GetEntDataFloat(iClient, g_iOffsetDisguiseCompleteTime))
+		OnClientDisguise(iClient);
 }
 
 public Action Client_Touch(int iClient, int iToucher)

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -172,18 +172,27 @@ stock void ApplyVoodooCursedSoul(int iClient)
 	SetVariantString("");
 	AcceptEntityInput(iClient, "SetCustomModel");
 	
-	TFClassType iClass = TF2_GetPlayerClass(iClient);
+	TFClassType nClass = TF2_GetPlayerClass(iClient);
 	SetEntProp(iClient, Prop_Send, "m_bForcedSkin", true);
-	SetEntProp(iClient, Prop_Send, "m_nForcedSkin", (iClass == TFClass_Spy) ? SKIN_ZOMBIE_SPY : SKIN_ZOMBIE);
+	SetEntProp(iClient, Prop_Send, "m_nForcedSkin", (nClass == TFClass_Spy) ? SKIN_ZOMBIE_SPY : SKIN_ZOMBIE);
 	
-	int iWearable = TF2_CreateAndEquipWeapon(iClient, g_iVoodooIndex[view_as<int>(iClass)]); //Not really a weapon, but still works
-	if (iWearable > MaxClients)
-		SetEntProp(iWearable, Prop_Send, "m_nModelIndexOverrides", g_iZombieSoulIndex[view_as<int>(iClass)]);
+	int iWearable = CreateVoodooWearable(iClient, nClass);
+	if (iWearable != INVALID_ENT_REFERENCE)
+		TF2_EquipWeapon(iClient, iWearable);
 }
 
-stock int GetClassVoodooItemDefIndex(TFClassType iClass)
+stock int CreateVoodooWearable(int iClient, TFClassType nClass)
 {
-	return g_iVoodooIndex[iClass];
+	int iWearable = TF2_CreateWeapon(iClient, g_iVoodooIndex[view_as<int>(nClass)]); //Not really a weapon, but still works
+	if (iWearable != INVALID_ENT_REFERENCE)
+		SetEntProp(iWearable, Prop_Send, "m_nModelIndexOverrides", g_iZombieSoulIndex[view_as<int>(nClass)]);
+	
+	return iWearable;
+}
+
+stock int GetClassVoodooItemDefIndex(TFClassType nClass)
+{
+	return g_iVoodooIndex[nClass];
 }
 
 stock void AddWeaponVision(int iWeapon, int iFlag)
@@ -622,7 +631,7 @@ stock void SetTeamRespawnTime(TFTeam nTeam, float flTime)
 // Weapon
 ////////////////
 
-stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, const char[] sAttribs = NULL_STRING, bool bAllowReskin = false)
+stock int TF2_CreateWeapon(int iClient, int iIndex, const char[] sAttribs = NULL_STRING, bool bAllowReskin = false)
 {
 	TFClassType iClass = TF2_GetPlayerClass(iClient);
 	char sClassname[256];
@@ -646,7 +655,7 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, const char[] sAttrib
 		Address pItem = SDKCall_GetLoadoutItem(iClient, iClass, iSlot);
 		
 		if (pItem && Config_GetOriginalItemDefIndex(LoadFromAddress(pItem+view_as<Address>(g_iOffsetItemDefinitionIndex), NumberType_Int16)) == iIndex)
-			iWeapon = SDKCall_GetBaseEntity(SDKCall_GiveNamedItem(iClient, sClassname, iSubType, pItem));
+			iWeapon = SDKCall_GiveNamedItem(iClient, sClassname, iSubType, pItem);
 	}
 	
 	if (iWeapon == -1)
@@ -680,13 +689,30 @@ stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, const char[] sAttrib
 		}
 		
 		DispatchSpawn(iWeapon);
-		SetEntProp(iWeapon, Prop_Send, "m_bValidatedAttachedEntity", true);
-		
-		if (StrContains(sClassname, "tf_wearable") == 0)
-			SDKCall_EquipWearable(iClient, iWeapon);
-		else
-			EquipPlayerWeapon(iClient, iWeapon);
 	}
+	
+	return iWeapon;
+}
+
+stock void TF2_EquipWeapon(int iClient, int iWeapon)
+{
+	SetEntProp(iWeapon, Prop_Send, "m_bValidatedAttachedEntity", true);
+	
+	char sClassname[256];
+	GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+	if (StrContains(sClassname, "tf_wearable") == 0)
+		SDKCall_EquipWearable(iClient, iWeapon);
+	else
+		EquipPlayerWeapon(iClient, iWeapon);
+}
+
+stock int TF2_CreateAndEquipWeapon(int iClient, int iIndex, const char[] sAttribs = NULL_STRING, bool bAllowReskin = false)
+{
+	int iWeapon = TF2_CreateWeapon(iClient, iIndex, sAttribs, bAllowReskin);
+	if (iWeapon == INVALID_ENT_REFERENCE)
+		return iWeapon;
+	
+	TF2_EquipWeapon(iClient, iWeapon);
 	
 	return iWeapon;
 }


### PR DESCRIPTION
Previously it only allows to disguise with matching target's class due to default disguise look not having zombie effects, giving an obvious look.

This change makes it so that if disguising as a class that no zombies is playing as, it then changes the look to have zombie skin, zombie cosmetic, and SZF's default melee weapon. This should make it as identical as any other zombies.

Disguising as Spy is disallowed because clientside does not allow to be able to show zombie skin, instead showing as a normal spy with a random mask class.

Disguising as Engineer however does not show it's Gunslinger hand correctly, which I'm not sure if it's possible to fix.