### PR TITLE
Add a bit of QoL related to the Tank

### DIFF
--- a/addons/sourcemod/configs/szf/classes.cfg
+++ b/addons/sourcemod/configs/szf/classes.cfg
@@ -254,6 +254,7 @@
 		{
 			"class"		"heavy"
 			"glow"		"1"
+			"message"	"SpecialInfected_Tank"
 			"menu"		"Menu_ClassesInfectedSpecialTank"
 			
 			"worldmodel"		"models/kirillian/infected/hank_v4.mdl"

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -404,6 +404,7 @@ ConVar g_cvTankHealthMin;
 ConVar g_cvTankHealthMax;
 ConVar g_cvTankTime;
 ConVar g_cvTankStab;
+ConVar g_cvTankDebrisLifetime;
 ConVar g_cvJockeyMovementVictim;
 ConVar g_cvJockeyMovementAttacker;
 ConVar g_cvFrenzyChance;

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -15,17 +15,18 @@ void ConVar_Init()
 	
 	g_cvForceOn = CreateConVar("sm_szf_force_on", "1", "<0/1> Force enable SZF for next map.", _, true, 0.0, true, 1.0);
 	g_cvRatio = CreateConVar("sm_szf_ratio", "0.78", "<0.01-1.00> Percentage of players that start as survivors.", _, true, 0.01, true, 1.0);
-	g_cvTankHealth = CreateConVar("sm_szf_tank_health", "400", "Amount of health the Tank gets per alive survivor", _, true, 10.0);
-	g_cvTankHealthMin = CreateConVar("sm_szf_tank_health_min", "1000", "Minimum amount of health the Tank can spawn with", _, true, 0.0);
-	g_cvTankHealthMax = CreateConVar("sm_szf_tank_health_max", "6000", "Maximum amount of health the Tank can spawn with", _, true, 0.0);
+	g_cvTankHealth = CreateConVar("sm_szf_tank_health", "400", "Amount of health the Tank gets per alive survivor.", _, true, 10.0);
+	g_cvTankHealthMin = CreateConVar("sm_szf_tank_health_min", "1000", "Minimum amount of health the Tank can spawn with.", _, true, 0.0);
+	g_cvTankHealthMax = CreateConVar("sm_szf_tank_health_max", "6000", "Maximum amount of health the Tank can spawn with.", _, true, 0.0);
 	g_cvTankTime = CreateConVar("sm_szf_tank_time", "30.0", "Adjusts the damage the Tank takes per second. 0 to disable.", _, true, 0.0);
-	g_cvTankStab = CreateConVar("sm_szf_tank_stab", "500", "Flat Damage dealt to the Tank from a backstab", _, true, 0.0);
-	g_cvJockeyMovementVictim = CreateConVar("sm_szf_jockey_movement_victim", "0.25", "Percentage of movement speed applied to victim from jockey grab", _, true, 0.0);
-	g_cvJockeyMovementAttacker = CreateConVar("sm_szf_jockey_movement_attacker", "0.75", "Percentage of movement speed applied to jockey during grab", _, true, 0.0);
-	g_cvFrenzyChance = CreateConVar("sm_szf_frenzy_chance", "0.0", "% Chance of a random frenzy", _, true, 0.0);
-	g_cvFrenzyTankChance = CreateConVar("sm_szf_frenzy_tank", "0.0", "% Chance of a Tank appearing instead of a frenzy", _, true, 0.0);
-	g_cvStunImmunity = CreateConVar("sm_szf_stun_immunity", "0.0", "How long until the survivor can be stunned again", _, true, 0.0);
-	g_cvMeleeIgnoreTeammates = CreateConVar("sm_szf_melee_ignores_teammates", "1.0", "<0/1> If enabled, melee hits will ignore teammates", _, true, 0.0, true, 1.0);
+	g_cvTankStab = CreateConVar("sm_szf_tank_stab", "500", "Flat Damage dealt to the Tank from a backstab.", _, true, 0.0);
+	g_cvTankDebrisLifetime = CreateConVar("sm_szf_tank_debris_lifetime", "20.0", "Amount of time (in seconds) it takes for debris thrown by Tanks to despawn. Use 0 to prevent despawning.", _, true, 0.0);
+	g_cvJockeyMovementVictim = CreateConVar("sm_szf_jockey_movement_victim", "0.25", "Percentage of movement speed applied to victim from jockey grab.", _, true, 0.0);
+	g_cvJockeyMovementAttacker = CreateConVar("sm_szf_jockey_movement_attacker", "0.75", "Percentage of movement speed applied to jockey during grab.", _, true, 0.0);
+	g_cvFrenzyChance = CreateConVar("sm_szf_frenzy_chance", "0.0", "% Chance of a random frenzy.", _, true, 0.0);
+	g_cvFrenzyTankChance = CreateConVar("sm_szf_frenzy_tank", "0.0", "% Chance of a Tank appearing instead of a frenzy.", _, true, 0.0);
+	g_cvStunImmunity = CreateConVar("sm_szf_stun_immunity", "0.0", "How long until the survivor can be stunned again.", _, true, 0.0);
+	g_cvMeleeIgnoreTeammates = CreateConVar("sm_szf_melee_ignores_teammates", "1.0", "<0/1> If enabled, melee hits will ignore teammates.", _, true, 0.0, true, 1.0);
 	
 	g_aConVar = new ArrayList(sizeof(ConVarInfo));
 	

--- a/addons/sourcemod/scripting/szf/infected.sp
+++ b/addons/sourcemod/scripting/szf/infected.sp
@@ -236,6 +236,10 @@ void Infected_ActivateDebris(int iClient, bool bVel)
 		AnglesToVelocity(vecAngles, vecVel, 2000.0);
 		TeleportEntity(iDebris, NULL_VECTOR, NULL_VECTOR, vecVel);
 	}
+	
+	float flLifetime = g_cvTankDebrisLifetime.FloatValue;
+	if (flLifetime > 0.0)
+		CreateTimer(flLifetime, Timer_KillEntity, iDebris);
 }
 
 public Action Infected_DebrisTimerEnd(Handle hTimer, int iSerial)

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -353,7 +353,7 @@
 	
 	"SpecialInfected_Tank"
 	{
-		"en"		"{green}YOU ARE A TANK:\n{orange}- A nearly-unstoppable force.\n- Call 'MEDIC!' to pick up and THROW DEBRIS ahead of you, hurting EVERYONE in its path!"
+		"en"		"{green}YOU ARE A TANK:\n{orange}- A nearly-unstoppable force.\n- Call 'MEDIC!' to pick up and THROW DEBRIS ahead of you, hurting EVERYONE in its path! {yellow}(5 second cooldown)"
 	}
 	
 	"SpecialInfected_Boomer"

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -351,6 +351,11 @@
 		"en"		"{1}Survivors can't change classes during a round"
 	}
 	
+	"SpecialInfected_Tank"
+	{
+		"en"		"{green}YOU ARE A TANK:\n{orange}- A nearly-unstoppable force.\n- Call 'MEDIC!' to pick up and THROW DEBRIS ahead of you, hurting EVERYONE in its path!"
+	}
+	
 	"SpecialInfected_Boomer"
 	{
 		"en"		"{green}YOU ARE A BOOMER:\n{orange}- Call 'MEDIC!' to EXPLODE and JARATE nearby enemies!\n- You also explode upon dying, coating the killer and assister in JARATE."


### PR DESCRIPTION
- Adds `sm_szf_tank_debris_lifetime`, which makes debris thrown by Tanks despawn after the specified amount of time. Default is 20.0 and can be set to 0.0 to never despawn. This is to prevent servers from lagging because of too many physics objects being active at once.
- Adds a spawn message for the Tank, similar to other special Infected. Since the Tank now has a "special ability," it makes sense to let players know about it.

![image](https://github.com/redsunservers/SuperZombieFortress/assets/33163183/196b4558-711d-4480-9b16-6ad4b6657490)
