### PR TITLE
Remove Damage Scaling

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1680,7 +1680,7 @@ void UpdateZombieDamageScale()
 	
 	//Post-calculation
 	if (g_flZombieDamageScale < 1.0)
-		g_flZombieDamageScale = Pow(g_flZombieDamageScale, 3.0);
+		g_flZombieDamageScale = Pow(g_flZombieDamageScale, 4.0);
 	
 	if (g_flZombieDamageScale < 0.2)
 		g_flZombieDamageScale = 0.2;

--- a/addons/sourcemod/scripting/szf/sdkhook.sp
+++ b/addons/sourcemod/scripting/szf/sdkhook.sp
@@ -144,17 +144,16 @@ public Action Client_OnTakeDamage(int iVictim, int &iAttacker, int &iInflicter, 
 		{
 			if (IsValidZombie(iAttacker))
 			{
-				// Damage scaling Zombies, don't make it too crazy for higher dmg scale
-				float flScale = g_flZombieDamageScale;
-				if (flScale > 1.0)
-					flScale = Pow(flScale, 0.5);
-				
-				flDamage = flDamage * flScale * 0.7; // Default: 0.7
+				// Damage multiplying Zombies
+				flDamage *= 0.6;
+
+				if (g_bZombieRage)
+					flDamage *= 1.15;
 			}
 			else if (IsValidSurvivor(iAttacker) && !IsClassname(iInflicter, "obj_sentrygun"))
 			{
 				// Damage scaling Survivors
-				flDamage /= g_flZombieDamageScale;
+				flDamage /= g_flZombieDamageScale * 1.4;
 			}
 			
 			bChanged = true;

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -1226,9 +1226,6 @@ stock void CPrintToChatDebug(const char[] sFormat, any ...)
 //SDKHooks_TakeDamage doesn't call OnTakeDamage, so we need to scale separately for 'indirect' damage
 stock void DealDamage(int iAttacker, int iVictim, float flDamage)
 {
-	if (g_flZombieDamageScale < 1.0)
-		flDamage *= g_flZombieDamageScale;
-	
 	SDKHooks_TakeDamage(iVictim, iAttacker, iAttacker, flDamage, DMG_PREVENT_PHYSICS_FORCE);
 }
 


### PR DESCRIPTION
- Removes zombie's damage dealt through scaling
  - Always deals 60% of damage
  - Damage increased by 15% during Frenzy
- Decreases zombie's damage taken by 30%
- Increases zombie's damage taken on low-scaling

Damage values could be adjusted as needed. Possibly as a convar in a future for easier changes.
Mainly done as it feels unfun for humans to take a random amount of damage and zombies to deal a random amount.