### PR TITLE
Update formula for zombie damage scale

### DIFF
--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1681,7 +1681,7 @@ void UpdateZombieDamageScale()
 	
 	//If the last point is being captured, increase damage scale
 	if (g_bCapturingLastPoint && !g_bSurvival)
-		g_flZombieDamageScale += g_cvScaleLastCP.FloatValue;
+		g_flZombieDamageScale *= g_cvScaleLastCP.FloatValue;
 	
 	//Post-calculation
 	if (g_flZombieDamageScale < 0.2)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1669,15 +1669,11 @@ void UpdateZombieDamageScale()
 	if (0.0 <= flProgress <= 1.0)
 		g_flZombieDamageScale += (flProgress * g_cvScaleProgress.FloatValue);
 	
-	float fl1 = g_flZombieDamageScale;
-	
 	//Lower damage scale as there are less survivors
 	float flSurvivorPercentage = float(iSurvivors) / float(iSurvivors + iZombies);
 	float flStartingPercentage = g_cvRatio.FloatValue;
 	float flMinScale = g_cvScaleSurvivors.FloatValue;
 	g_flZombieDamageScale *= (flSurvivorPercentage + flMinScale) / (flStartingPercentage + flMinScale);
-	
-	float fl2 = g_flZombieDamageScale;
 	
 	//Zombie rage increases damage
 	if (g_bZombieRage)

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -18,7 +18,7 @@ void ConVar_Init()
 	g_cvRatio = CreateConVar("sm_szf_ratio", "0.80", "<0.01-1.00> Percentage of players that start as survivors.", _, true, 0.01, true, 1.0);
 	g_cvScaleProgress = CreateConVar("sm_szf_scale_progress", "0.4", "Max amount of scale to add from map progress.", _, true, 0.0);
 	g_cvScaleSurvivors = CreateConVar("sm_szf_scale_survivors", "0.1", "Min amount to multiply the scale from % of survivors", _, true, 0.0, true, 1.0);
-	g_cvScaleLastCP = CreateConVar("sm_szf_scale_lastcp", "0.1", "Amount of scale to add when the last control point is being captured", _, true, 0.0);
+	g_cvScaleLastCP = CreateConVar("sm_szf_scale_lastcp", "1.25", "Scale multiplier to apply when the last control point is being captured", _, true, 0.0);
 	g_cvWeaponSpawnReappear = CreateConVar("sm_szf_weapon_spawn_reappear", "0.25", "% chance for spawn weapons to reappear.", _, true, 0.0, true, 1.0);
 	g_cvWeaponPickupChance = CreateConVar("sm_szf_weapon_pickup_chance", "0.07", "% chance for normal weapons to be pickups.", _, true, 0.0, true, 1.0);
 	g_cvWeaponRareChance = CreateConVar("sm_szf_weapon_rare_chance", "0.2", "% chance for normal weapons to be rare.", _, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -16,6 +16,9 @@ void ConVar_Init()
 	g_cvForceOn = CreateConVar("sm_szf_force_on", "1", "<0/1> Force enable SZF for next map.", _, true, 0.0, true, 1.0);
 	g_cvDebug = CreateConVar("sm_szf_debug", "0", "Enable debugs?", _, true, 0.0, true, 1.0);
 	g_cvRatio = CreateConVar("sm_szf_ratio", "0.80", "<0.01-1.00> Percentage of players that start as survivors.", _, true, 0.01, true, 1.0);
+	g_cvScaleProgress = CreateConVar("sm_szf_scale_progress", "0.4", "Max amount of scale to add from map progress.", _, true, 0.0);
+	g_cvScaleSurvivors = CreateConVar("sm_szf_scale_survivors", "0.1", "Min amount to multiply the scale from % of survivors", _, true, 0.0, true, 1.0);
+	g_cvScaleLastCP = CreateConVar("sm_szf_scale_lastcp", "0.1", "Amount of scale to add when the last control point is being captured", _, true, 0.0);
 	g_cvWeaponSpawnReappear = CreateConVar("sm_szf_weapon_spawn_reappear", "0.25", "% chance for spawn weapons to reappear.", _, true, 0.0, true, 1.0);
 	g_cvWeaponPickupChance = CreateConVar("sm_szf_weapon_pickup_chance", "0.07", "% chance for normal weapons to be pickups.", _, true, 0.0, true, 1.0);
 	g_cvWeaponRareChance = CreateConVar("sm_szf_weapon_rare_chance", "0.2", "% chance for normal weapons to be rare.", _, true, 0.0, true, 1.0);


### PR DESCRIPTION
Currently the scale was quite complicated to calculate, but a sudden change from scaling likely comes from the ^3.0 exponential, and last control point can double up the scaling.

The new formula now have it all scaled by linear. Map progress increases scale up to 40%, and few survivors can lower scale down by 90%. Last control point now only increases scale up by a flat +0.1.

Want to see this get tested before merging it.