### PR TITLE
4.7.2

### DIFF
--- a/addons/sourcemod/configs/szf/classes.cfg
+++ b/addons/sourcemod/configs/szf/classes.cfg
@@ -74,6 +74,7 @@
 		
 		"engineer"
 		{
+			"health"	"25"
 			"menu"		"Menu_ClassesSurvivorsEngineer"
 		}
 		

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -792,7 +792,7 @@
 		"304"	//Amputator
 		{
 			"text"		"Melee_Amputator"
-			"attrib"	"200 ; 0.0 ; 57 ; 2.0"
+			"attrib"	"200 ; 0.0"
 		}
 		"171"	//Tribalman's Shiv
 		{

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -766,6 +766,11 @@
 			"text"		"Melee_FistsofSteel"
 			"attrib"	"206 ; 0.9"
 		}
+		"426"	//Eviction Notice
+		{
+			"text"		"Melee_EvictionNotice"
+			"attrib"	"855 ; 0.0 ; 414 ; 1.0"
+		}
 		"142"	//Gunslinger
 		{
 			"attrib"	"26 ; 0.0"

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -56,7 +56,7 @@
 		
 		"220" // Shortstop
 		{
-			"rarity"		"uncommon"
+			"rarity"		"rare"
 			"model"			"models/weapons/c_models/c_shortstop/c_shortstop.mdl"
 		}
 		
@@ -68,7 +68,7 @@
 		
 		"772" // Baby Face's Blaster
 		{
-			"rarity"		"rare"
+			"rarity"		"uncommon"
 			"model"			"models/weapons/c_models/c_pep_scattergun.mdl"
 		}
 		
@@ -105,7 +105,7 @@
 		
 		"449" // Winger
 		{
-			"rarity"		"common"
+			"rarity"		"uncommon"
 			"model"			"models/weapons/c_models/c_winger_pistol/c_winger_pistol.mdl"
 		}
 		
@@ -328,7 +328,7 @@
 		
 		"1099" // Tide Turner
 		{
-			"rarity"		"common"
+			"rarity"		"uncommon"
 			"model"			"models/workshop/weapons/c_models/c_wheel_shield/c_wheel_shield.mdl"
 			"origin_offset"	"0.0 0.0 4.0"
 			"angles_offset"	"0.0 0.0 -90.0"
@@ -378,7 +378,7 @@
 		
 		"159" // Dalokohs Bar
 		{
-			"rarity"		"common"
+			"rarity"		"uncommon"
 			"model"			"models/weapons/c_models/c_chocolate/c_chocolate.mdl"
 			"angles_offset"	"0.0 0.0 -90.0"
 		}
@@ -398,7 +398,7 @@
 		
 		"1190" // Second Banana
 		{
-			"rarity"		"uncommon"
+			"rarity"		"common"
 			"model"			"models/weapons/c_models/c_banana/c_banana.mdl"
 			"angles_offset"	"0.0 0.0 -90.0"
 		}
@@ -609,13 +609,13 @@
 		
 		"735" // Sapper
 		{
-			"rarity"		"uncommon"
+			"rarity"		"common"
 			"model"			"models/weapons/c_models/c_sapper/c_sapper.mdl"
 		}
 
 		"810" // Red-Tape Recorder
 		{
-			"rarity"		"uncommon"
+			"rarity"		"common"
 			"model"			"models/weapons/w_models/w_sd_sapper.mdl"
 		}
 		

--- a/addons/sourcemod/configs/szf/weapons.cfg
+++ b/addons/sourcemod/configs/szf/weapons.cfg
@@ -766,6 +766,10 @@
 			"text"		"Melee_FistsofSteel"
 			"attrib"	"206 ; 0.9"
 		}
+		"142"	//Gunslinger
+		{
+			"attrib"	"26 ; 0.0"
+		}
 		"589"	//Eureka Effect
 		{
 			"text"		"Melee_EurekaEffect"

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -392,6 +392,9 @@ Handle g_hTimerProgress;
 ConVar g_cvForceOn;
 ConVar g_cvDebug;
 ConVar g_cvRatio;
+ConVar g_cvScaleProgress;
+ConVar g_cvScaleSurvivors;
+ConVar g_cvScaleLastCP;
 ConVar g_cvWeaponSpawnReappear;
 ConVar g_cvWeaponPickupChance;
 ConVar g_cvWeaponRareChance;
@@ -1680,24 +1683,23 @@ void UpdateZombieDamageScale()
 	
 	//If progress found, calculate add progress to damage scale
 	if (0.0 <= flProgress <= 1.0)
-		g_flZombieDamageScale += flProgress;
+		g_flZombieDamageScale += (flProgress * g_cvScaleProgress.FloatValue);
 	
 	//Lower damage scale as there are less survivors
 	float flSurvivorPercentage = float(iSurvivors) / float(iSurvivors + iZombies);
-	g_flZombieDamageScale = (g_flZombieDamageScale * flSurvivorPercentage * 0.6) + 0.5;
+	float flStartingPercentage = g_cvRatio.FloatValue;
+	float flMinScale = g_cvScaleSurvivors.FloatValue;
+	g_flZombieDamageScale *= (flSurvivorPercentage + flMinScale) / (flStartingPercentage + flMinScale);
 	
 	//Zombie rage increases damage
 	if (g_bZombieRage)
 		g_flZombieDamageScale *= 1.15;
 	
-	//If the last point is being captured, increase damage scale if lower than 100%
-	if (g_bCapturingLastPoint && g_flZombieDamageScale < 1.0 && !g_bSurvival)
-		g_flZombieDamageScale += (1.0 - g_flZombieDamageScale) * 0.5;
+	//If the last point is being captured, increase damage scale
+	if (g_bCapturingLastPoint && !g_bSurvival)
+		g_flZombieDamageScale *= g_cvScaleLastCP.FloatValue;
 	
 	//Post-calculation
-	if (g_flZombieDamageScale < 1.0)
-		g_flZombieDamageScale = Pow(g_flZombieDamageScale, 3.0);
-	
 	if (g_flZombieDamageScale < 0.2)
 		g_flZombieDamageScale = 0.2;
 	

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -19,7 +19,7 @@
 
 #include "include/superzombiefortress.inc"
 
-#define PLUGIN_VERSION				"4.7.1"
+#define PLUGIN_VERSION				"4.7.2"
 #define PLUGIN_VERSION_REVISION		"manual"
 
 #define MAX_CONTROL_POINTS	8
@@ -343,6 +343,13 @@ char g_sInfectedNames[view_as<int>(Infected_Count)][] = {
 	"Smoker",
 	"Spitter",
 	"Jockey",
+};
+
+#define SPITTER_SPIT_MODEL	"models/weapons/w_bugbait.mdl"
+
+char g_sSpitterParticles[][] = {
+	"unusual_risingstar_green_glow",
+	"unusual_meteor_fireball_small_green",
 };
 
 Cookie g_cFirstTimeSurvivor;
@@ -1369,13 +1376,19 @@ void SZFEnable()
 	DetermineControlPoints();
 	PrecacheZombieSouls();
 	
+	// Generic Rage
 	PrecacheParticle("spell_cast_wheel_blue");
 	
-	//Boomer
+	// Boomer
 	PrecacheParticle("asplode_hoodoo_debris");
 	PrecacheParticle("asplode_hoodoo_dust");
 	
-	//Map pickup
+	// Spitter
+	PrecacheModel(SPITTER_SPIT_MODEL);
+	for (int i = 0; i < sizeof(g_sSpitterParticles); i++)
+		PrecacheParticle(g_sSpitterParticles[i]);
+	
+	// Map pickup
 	PrecacheSound("ui/item_paint_can_pickup.wav");
 	
 	if (GameRules_GetRoundState() < RoundState_Preround)

--- a/addons/sourcemod/scripting/superzombiefortress.sp
+++ b/addons/sourcemod/scripting/superzombiefortress.sp
@@ -1391,6 +1391,9 @@ void SZFEnable()
 	// Map pickup
 	PrecacheSound("ui/item_paint_can_pickup.wav");
 	
+	// Disable holiday lights from ropes for Smoker tongue
+	GameRules_SetProp("m_bRopesHolidayLightsAllowed", false);
+	
 	if (GameRules_GetRoundState() < RoundState_Preround)
 	{
 		g_nRoundState = SZFRoundState_Setup;

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -16,6 +16,9 @@ void ConVar_Init()
 	g_cvForceOn = CreateConVar("sm_szf_force_on", "1", "<0/1> Force enable SZF for next map.", _, true, 0.0, true, 1.0);
 	g_cvDebug = CreateConVar("sm_szf_debug", "0", "Enable debugs?", _, true, 0.0, true, 1.0);
 	g_cvRatio = CreateConVar("sm_szf_ratio", "0.80", "<0.01-1.00> Percentage of players that start as survivors.", _, true, 0.01, true, 1.0);
+	g_cvScaleProgress = CreateConVar("sm_szf_scale_progress", "0.4", "Max amount of scale to add from map progress.", _, true, 0.0);
+	g_cvScaleSurvivors = CreateConVar("sm_szf_scale_survivors", "0.1", "Min amount to multiply the scale from % of survivors", _, true, 0.0, true, 1.0);
+	g_cvScaleLastCP = CreateConVar("sm_szf_scale_lastcp", "1.25", "Scale multiplier to apply when the last control point is being captured", _, true, 0.0);
 	g_cvWeaponSpawnReappear = CreateConVar("sm_szf_weapon_spawn_reappear", "0.25", "% chance for spawn weapons to reappear.", _, true, 0.0, true, 1.0);
 	g_cvWeaponPickupChance = CreateConVar("sm_szf_weapon_pickup_chance", "0.07", "% chance for normal weapons to be pickups.", _, true, 0.0, true, 1.0);
 	g_cvWeaponRareChance = CreateConVar("sm_szf_weapon_rare_chance", "0.2", "% chance for normal weapons to be rare.", _, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/szf/convar.sp
+++ b/addons/sourcemod/scripting/szf/convar.sp
@@ -45,8 +45,9 @@ void ConVar_Init()
 	g_cvMeleeIgnoreTeammates = CreateConVar("sm_szf_melee_ignores_teammates", "1.0", "<0/1> If enabled, melee hits will ignore teammates.", _, true, 0.0, true, 1.0);
 	g_cvPunishAvoidingPlayers = CreateConVar("sm_szf_punish_avoiding_players", "1.0", "<0/1> If enabled, players who avoid playing on the Infected team will be forced back into it in the next round they play.", _, true, 0.0, true, 1.0);
 	
-	ConVar_InitEvent(g_FrenzyEvent, "frenzy", "60.0", "150.0", "0.1", "50");
-	ConVar_InitEvent(g_TankEvent, "tank", "120.0", "240.0", "0.1", "80");
+	//                              syntax    cooldown interval threshold killspree progress
+	ConVar_InitEvent(g_FrenzyEvent, "frenzy", "60.0",  "150.0", "0.1",    "50",     "0.2");
+	ConVar_InitEvent(g_TankEvent,   "tank",   "120.0", "240.0", "0.1",    "80",     "0.3");
 	
 	g_aConVar = new ArrayList(sizeof(ConVarInfo));
 	
@@ -65,13 +66,14 @@ void ConVar_Init()
 	ConVar_Add("tf_weapon_criticals", 0.0);
 }
 
-void ConVar_InitEvent(ConVarEvent event, const char[] sSyntax, const char[] sCooldown, const char[] sInterval, const char[] sThreshold, const char[] sKillSpree)
+void ConVar_InitEvent(ConVarEvent event, const char[] sSyntax, const char[] sCooldown, const char[] sInterval, const char[] sThreshold, const char[] sKillSpree, const char[] sProgress)
 {
 	event.cvCooldown = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_cooldown"), sCooldown, ConVar_FormatString(sSyntax, "Cooldown in seconds for %s."), _, true, 0.0);
 	event.cvSurvivorDeathInterval = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_survivor_death_interval"), sInterval, ConVar_FormatString(sSyntax, "Check in the past seconds on how many survivors died to trigger %s."), _, true, 0.0);
 	event.cvSurvivorDeathThreshold = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_survivor_death_threshold"), sThreshold, ConVar_FormatString(sSyntax, "Min %% amount of survivors who have died in the past seconds to trigger %s."), _, true, 0.0, true, 1.0);
 	event.cvKillSpree = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_killspree"), sKillSpree, ConVar_FormatString(sSyntax, "Amount of infected deaths to trigger %s, multiplied by %% of infecteds."), _, true, 0.0);
-	event.cvChance = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_chance"), "0.0", ConVar_FormatString(sSyntax, "%% Chance of a %s frenzy."), _, true, 0.0, true, 1.0);
+	event.cvProgress = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_progress"), sProgress, ConVar_FormatString(sSyntax, "Min %% of playerbase being survivor to trigger %s by map progress."), _, true, 0.0, true, 1.0);
+	event.cvChance = CreateConVar(ConVar_FormatString(sSyntax, "sm_szf_%s_chance"), "0.0", ConVar_FormatString(sSyntax, "%% Chance of a random %s."), _, true, 0.0, true, 1.0);
 }
 
 char[] ConVar_FormatString(const char[] sSyntax, const char[] sName)

--- a/addons/sourcemod/scripting/szf/sdkhook.sp
+++ b/addons/sourcemod/scripting/szf/sdkhook.sp
@@ -12,6 +12,10 @@ void SDKHook_OnEntityCreated(int iEntity, const char[] sClassname)
 	{
 		SDKHook(iEntity, SDKHook_SpawnPost, Pickup_SpawnPost);
 	}
+	else if (StrEqual(sClassname, "tf_projectile_jar_gas"))
+	{
+		SDKHook(iEntity, SDKHook_SpawnPost, GasProjectile_SpawnPost);
+	}
 	else if (StrEqual(sClassname, "tf_gas_manager"))
 	{
 		SDKHook(iEntity, SDKHook_Touch, GasManager_Touch);
@@ -364,6 +368,21 @@ public Action Pickup_BananaTouch(int iEntity, int iToucher)
 	}
 	
 	return Plugin_Continue;
+}
+
+public void GasProjectile_SpawnPost(int iGasProjectile)
+{
+	int iOwner = GetEntPropEnt(iGasProjectile, Prop_Send, "m_hOwnerEntity");
+	if (!IsValidZombie(iOwner))
+		return;
+	
+	SetEntityRenderMode(iGasProjectile, RENDER_TRANSCOLOR);
+	SetEntityRenderColor(iGasProjectile, 0, 255, 0, 255);
+	SetEntPropFloat(iGasProjectile, Prop_Send, "m_flModelScale", 1.5);
+	
+	SetEntityModel(iGasProjectile, SPITTER_SPIT_MODEL);
+	for (int i = 0; i < sizeof(g_sSpitterParticles); i++)
+		AttachParticle(iGasProjectile, g_sSpitterParticles[i]);
 }
 
 public Action GasManager_Touch(int iGasManager, int iClient)

--- a/addons/sourcemod/scripting/szf/stocks.sp
+++ b/addons/sourcemod/scripting/szf/stocks.sp
@@ -1068,7 +1068,7 @@ bool Trace_DontHitTeammates(int iEntity, int iMask, any iData)
 // Particles
 ////////////////
 
-stock int ShowParticle(char[] sParticle, float flDuration, float vecPos[3], float vecAngles[3] = NULL_VECTOR)
+stock int ShowParticle(const char[] sParticle, float flDuration, float vecPos[3], float vecAngles[3] = NULL_VECTOR)
 {
 	int iParticle = CreateEntityByName("info_particle_system");
 	if (IsValidEdict(iParticle))
@@ -1086,6 +1086,44 @@ stock int ShowParticle(char[] sParticle, float flDuration, float vecPos[3], floa
 	}
 	
 	return iParticle;
+}
+
+stock void AttachParticle(int iEntity, const char[] sParticle)
+{
+	// find string table
+	int iTable = FindStringTable("ParticleEffectNames");
+	if (iTable == INVALID_STRING_TABLE)
+		return;
+	
+	// find particle index
+	char sBuffer[256];
+	int iCount = GetStringTableNumStrings(iTable);
+	int iIndex = INVALID_STRING_INDEX;
+	for (int i; i < iCount; i++)
+	{
+		ReadStringTable(iTable, i, sBuffer, sizeof(sBuffer));
+		if (StrEqual(sBuffer, sParticle, false))
+		{
+			iIndex = i;
+			break;
+		}
+	}
+
+	if (iIndex == INVALID_STRING_INDEX)
+		return;
+	
+	TE_Start("TFParticleEffect");
+	TE_WriteFloat("m_vecOrigin[0]", 100000.0);
+	TE_WriteFloat("m_vecOrigin[1]", 100000.0);
+	TE_WriteFloat("m_vecOrigin[2]", 100000.0);
+	TE_WriteNum("m_iParticleSystemIndex", iIndex);
+
+	TE_WriteNum("entindex", iEntity);
+	TE_WriteNum("m_iAttachType", -1);
+	TE_WriteNum("m_iAttachmentPointIndex", 6);
+	TE_WriteNum("m_bResetParticles", false);
+
+	TE_SendToAll(0.0);
 }
 
 stock void PrecacheParticle(char[] sParticleName)

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -397,6 +397,11 @@
 	{
 		"en"		"{orange}The Fists of Steel {green}gives 10%% melee resistance while active."
 	}
+
+	"Melee_EvictionNotice"
+	{
+		"en"		"{orange}The Eviction Notice {green}has its health drain disabled. {red}Marked-For-Death while active."
+	}
 	
 	"Melee_EurekaEffect"
 	{

--- a/addons/sourcemod/translations/superzombiefortress.phrases.txt
+++ b/addons/sourcemod/translations/superzombiefortress.phrases.txt
@@ -515,7 +515,7 @@
 	
 	"Menu_ClassesSurvivorsEngineer"
 	{
-		"en"		"Starts with PDAs.\nCan only build sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished.\nDispensers are minis, decays on health and ammo dispenses."
+		"en"		"Has 25 extra max health.\nStarts with PDAs.\nCan only build sentries and dispensers, and cannot be upgraded.\nSentry ammo is limited, decays and cannot be replenished.\nDispensers are minis, decays on health and ammo dispenses."
 	}
 	
 	"Menu_ClassesSurvivorsMedic"


### PR DESCRIPTION
- Update formula to calculate zombie damage scale
- Trigger frenzy/tank if there too many survivors during lategame
- Give Spitter's spit a model and particles
- Disable rope's holiday lights for Smoker tongue
- Increase Engineer's max health by 25 (Gunslinger loses it's extra max health for this change)
- Update Eviction Notice to replace health drain to Marked-For-Death while active.
- Remove Amputator's hidden -1 regen penalty
- Update several weapon rarities:
  - Shortstop (uncommon -> rare)
  - Baby Face Blaster (rare -> uncommon)
  - Winger (common -> uncommon)
  - Tide Turner (common -> uncommon)
  - Dalokohs Bar (common -> uncommon)
  - Second Banana (uncommon -> common)
  - Sapper (uncommon -> common)
  - Red-Tape Recorder (uncommon -> common)